### PR TITLE
Rewrite of the Linux Amd64 transpiler to use the new intermediate representation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ import { Lowerer } from './lowerer/lowerer';
 import os from 'os';
 import { Parser } from './parser/parser';
 import Path from 'path';
-import { SemanticTreeTranspiler } from './transpiler/semanticTreeTranspiler';
 import { TargetPlatform } from './options/targetPlatform';
 import { Transpiler } from './transpiler/transpiler';
 import { TranspilerAmd64Linux } from './transpiler/amd64/linux/transpilerAmd64Linux';
@@ -52,7 +51,7 @@ class Main
         const importer = new Importer(diagnostic, lexer, parser, standardLibraryTargetPath);
         const connector = new Connector(diagnostic);
         const lowerer = new Lowerer();
-        let transpiler: Transpiler|SemanticTreeTranspiler;
+        let transpiler: Transpiler|TranspilerAvr;
         let assembler: Assembler;
         let linker: Linker;
 
@@ -95,7 +94,14 @@ class Main
                 FileSystem.writeFileSync('tmp/test.phi', intermediateCode, {encoding: 'utf8'});
             }
 
-            assembly = transpiler.run(semanticTree);
+            if (transpiler instanceof TranspilerAvr)
+            {
+                assembly = transpiler.run(semanticTree);
+            }
+            else
+            {
+                assembly = transpiler.run(intermediateLanguage);
+            }
 
             diagnostic.end();
         }

--- a/src/transpiler/amd64/linux/directiveInstruction.ts
+++ b/src/transpiler/amd64/linux/directiveInstruction.ts
@@ -1,0 +1,19 @@
+import * as Instructions from '../../common/instructions';
+
+/**
+ * An instruction with its render options set according to NASM Assembler directives
+ */
+export class DirectiveInstruction extends Instructions.Instruction
+{
+    constructor (command: string, ...operands: string[])
+    {
+        super(command, ...operands);
+
+        this.renderOptions = {
+            commandOperandSplitter: ' ',
+            operandSplitter: ' ',
+            prefix: '[',
+            postfix: ']',
+        };
+    }
+}

--- a/src/transpiler/amd64/linux/locationManagerAmd64Linux.ts
+++ b/src/transpiler/amd64/linux/locationManagerAmd64Linux.ts
@@ -1,372 +1,248 @@
-import * as SemanticSymbols from '../../../connector/semanticSymbols';
-import { LocationedVariableAmd64 } from '../locationedVariableAmd64';
+import * as Instructions from '../../common/instructions';
+import * as IntermediateSymbols from '../../../lowerer/intermediateSymbols';
+import { IntermediateSize } from '../../../lowerer/intermediateSize';
 import { Register64Amd64 } from '../registers/register64Amd64';
 import { RegistersAmd64Linux } from './registersAmd64Linux';
 
-type VariableStack = Map<SemanticSymbols.Variable, LocationedVariableAmd64>;
-
-// TODO: This must be reworked.
-//       We need a very simple location manager that puts everything onto the stack for debugging.
-//       And then use, when compiling in optimised mode, this smart approach.
-export abstract class LocationManagerAmd64Linux
+/**
+ * Location manager with optimisation level "none". \
+ * Puts everything onto the stack and only uses registers where needed.
+ */
+export class LocationManagerAmd64LinuxNone
 {
-    protected abstract code: string[];
-
-    /**
-     * A list of variable lists, working as a stack.
-     * At the beginning of each function and section a new list is pushed, at the end of them it is removed.
-     * With this we keep track of which variables are used at which point in the code.
-     */
-    private variableStacks: VariableStack[];
-
-    /**
-     * The set of registers currently in use.
-     */
-    private registersInUse: Set<Register64Amd64>;
-
-    /**
-     * The map of used callee saved registers (to their stack location) that must be restored at the end of the function.
-     */
-    private usedCalleeSavedRegisters: Map<Register64Amd64, string>;
-
-    /**
-     * A list of currently saved register lists. Before a function call a list is added and filled, after it is removed again.
-     */
-    private currentlySavedRegistersList: Register64Amd64[][];
+    private instructions: Instructions.Instruction[];
 
     /**
      * The current offset of the base pointer, equivalent to the current stack frame size.
      */
     private currentBasePointerOffset: number;
 
-    private get lastVariableStack (): VariableStack
+    /* TODO: Should we only use names here instead of symbols?
+             Is it guaranteed that the intermediate variable names are unique (in which scope)? */
+    private variableToStackLocation: Map<IntermediateSymbols.Variable, string>;
+
+    private variableToRegister: Map<IntermediateSymbols.Variable, Register64Amd64>;
+
+    private registersInUse: Set<Register64Amd64>;
+
+    constructor (instructions: Instructions.Instruction[])
     {
-        const lastVariableStack = this.variableStacks[this.variableStacks.length - 1];
+        this.instructions = instructions;
+        this.variableToStackLocation = new Map();
+        this.variableToRegister = new Map();
+        this.registersInUse = new Set();
 
-        return lastVariableStack;
-    }
-
-    private get nextStackLocation (): string
-    {
-        // TODO: Replace the hardcoded size with the real type sizes:
-        const stackLocation = `[${RegistersAmd64Linux.stackBasePointer.bit64}-${this.currentBasePointerOffset}]`;
-        this.currentBasePointerOffset += 8;
-        this.code.push(`sub ${RegistersAmd64Linux.stackPointer.bit64}, 8`);
-
-        return stackLocation;
-    }
-
-    constructor ()
-    {
-        this.variableStacks = [];
-        this.registersInUse = new Set<Register64Amd64>();
-        this.usedCalleeSavedRegisters = new Map<Register64Amd64, string>();
-        this.currentlySavedRegistersList = [];
         this.currentBasePointerOffset = 0;
     }
 
-    protected addNewVariableStack (isFunctionInitialisation = false): void
+    private intermediateSizeToByteSize (intermediateSize: IntermediateSize): 1 | 2 | 4 | 8
     {
-        const newStack = new Map<SemanticSymbols.Variable, LocationedVariableAmd64>();
-
-        this.variableStacks.push(newStack);
-
-        if (isFunctionInitialisation)
+        switch (intermediateSize)
         {
-            this.registersInUse.clear();
-            this.usedCalleeSavedRegisters.clear();
-            this.currentBasePointerOffset = 0;
+            case IntermediateSize.Int8:
+                return 1;
+            case IntermediateSize.Int16:
+                return 2;
+            case IntermediateSize.Int32:
+                return 4;
+            case IntermediateSize.Int64:
+            case IntermediateSize.Native:
+            case IntermediateSize.Pointer:
+                return 8;
+            case IntermediateSize.Void:
+                throw new Error('Transpiler error: Cannot get the byte size of type "Void".');
         }
     }
 
-    protected removeLastVariableStack (isFunctionFinalisation = false): void
+    private getRegisterNameForSize (register: Register64Amd64, intermediateSize: IntermediateSize): string
     {
-        for (const variable of this.lastVariableStack.keys())
+        const byteSize = this.intermediateSizeToByteSize(intermediateSize);
+
+        switch (byteSize)
         {
-            this.freeVariable(variable);
+            case 1:
+                return register.bit8;
+            case 2:
+                return register.bit16;
+            case 4:
+                return register.bit32;
+            case 8:
+                return register.bit64;
+        }
+    }
+
+    public enterFunction (): void
+    {
+        this.currentBasePointerOffset = 0;
+
+        if (this.variableToStackLocation.size > 0)
+        {
+            // TODO: Should this be a diagnostic error? If yes, we would need to know when exactly the variables have not been dismissed.
+            throw new Error('Transpiler error: Not all variables have been dismissed.');
         }
 
-        this.variableStacks.pop();
-
-        if (isFunctionFinalisation)
+        if ((this.variableToRegister.size > 0) || (this.registersInUse.size > 0))
         {
-            // Restore the callee saved registers:
-            for (const [register, location] of this.usedCalleeSavedRegisters)
+            // TODO: Should this be a diagnostic error? If yes, we would need to know when exactly the variables have not been unpinned.
+            throw new Error('Transpiler error: Not all variables have been unpinned.');
+        }
+
+        this.instructions.push(
+            // Save base pointer:
+            new Instructions.Instruction('push', RegistersAmd64Linux.stackBasePointer.bit64),
+            // Set base pointer to current stack pointer:
+            new Instructions.Instruction('mov', RegistersAmd64Linux.stackBasePointer.bit64, RegistersAmd64Linux.stackPointer.bit64),
+        );
+    }
+
+    public leaveFunction (): void
+    {
+        this.instructions.push(
+            new Instructions.Instruction('leave'),
+        );
+    }
+
+    public introduce (variableSymbol: IntermediateSymbols.Variable): void
+    {
+        const stackLocation = `[${RegistersAmd64Linux.stackBasePointer.bit64}-${this.currentBasePointerOffset}]`;
+
+        //const variableSizeInBytes = this.intermediateSizeToByteSize(variableSymbol.size);
+        const variableSizeInBytes = 8;
+
+        this.instructions.push(
+            new Instructions.Instruction('sub', RegistersAmd64Linux.stackPointer.bit64, `${variableSizeInBytes}`),
+        );
+
+        this.currentBasePointerOffset += variableSizeInBytes;
+
+        this.variableToStackLocation.set(variableSymbol, stackLocation);
+    }
+
+    public dismiss (variableSymbol: IntermediateSymbols.Variable): void
+    {
+        this.variableToStackLocation.delete(variableSymbol);
+    }
+
+    public getLocation (variableSymbol: IntermediateSymbols.Variable): string
+    {
+        if (this.variableToRegister.has(variableSymbol))
+        {
+            const register = this.variableToRegister.get(variableSymbol);
+
+            if (register === undefined)
             {
-                this.code.push(`mov ${register.bit64}, QWORD ${location}`); // Saved registers must always be the full 8 bytes long.
+                throw new Error('Transpiler error: Map.has returned true while Map.get returned undefined.');
             }
+
+            const registerName = this.getRegisterNameForSize(register, variableSymbol.size);
+
+            return registerName;
+        }
+        else
+        {
+            const stackLocation = this.variableToStackLocation.get(variableSymbol);
+
+            if (stackLocation === undefined)
+            {
+                throw new Error('Transpiler error: Variable has been used before it has been introduced.');
+            }
+
+            return stackLocation;
         }
     }
 
     /**
-     * Push a variable to a location.
-     * @param variable The variable to push.
-     * @param location The location to push to. If ommitted the next free register is used, or if none is free the memory.
-     * @param saveToMemoryWhenInUse If true and the location is in use, the content will be moved to the memory and not to a free register.
-     *                              This can be used to keep the registers free, e.g. before a function call.
+     * Pins the given variable to any free register until it is unpinned.
      */
-    protected pushVariable (variable: SemanticSymbols.Variable, location?: Register64Amd64|string, saveToMemoryWhenInUse = false): LocationedVariableAmd64
+    public pinVariableToRegister (variableSymbol: IntermediateSymbols.Variable): void
     {
-        let targetLocation: Register64Amd64|string;
-
-        if (location === undefined)
-        {
-            targetLocation = this.getNextLocation();
-        }
-        else
-        {
-            // If the location is a register in use we must free it before we can use it.
-
-            if ((location instanceof Register64Amd64) && (this.registersInUse.has(location)))
-            {
-                const locationedVariable = this.getVariableForLocation(location);
-
-                // Get the next stack location if it must be saved to memory, otherwise simply get the next location:
-                const newVariableLocation = saveToMemoryWhenInUse ? this.nextStackLocation : this.getNextLocation();
-
-                const oldLocationString = locationedVariable.locationString;
-
-                locationedVariable.location = newVariableLocation;
-
-                this.code.push(`mov ${locationedVariable.locationString}, ${oldLocationString}`);
-            }
-
-            targetLocation = location;
-        }
-
-        const locationedVariable = new LocationedVariableAmd64(variable, targetLocation);
-
-        this.lastVariableStack.set(variable, locationedVariable);
-
-        return locationedVariable;
-    }
-
-    private getVariableForLocation (location: Register64Amd64|string): LocationedVariableAmd64
-    {
-        for (const variableStack of this.variableStacks)
-        {
-            for (const locationedVariable of variableStack.values())
-            {
-                if (locationedVariable.location == location)
-                {
-                    return locationedVariable;
-                }
-            }
-        }
-
-        let locationAsString: string;
-        if (location instanceof Register64Amd64)
-        {
-            locationAsString = location.bit64;
-        }
-        else
-        {
-            locationAsString = location;
-        }
-
-        throw new Error(`Transpiler error: For the given location "${locationAsString}" there is no variable known.`);
-    }
-
-    private getNextLocation (): Register64Amd64|string
-    {
-        const register = this.getNextFreeRegister();
-
-        if (register === null)
-        {
-            const stackLocation = this.nextStackLocation;
-
-            return stackLocation;
-        }
-        else
-        {
-            return register;
-        }
-    }
-
-    private getNextFreeRegister (): Register64Amd64|null
-    {
-        // Priority of registers: Caller saved, arguments, callee saved.
-        // FIXME: We must save callee saved registers before use and restore them after it or at the end of the function!
-        const registers = [...RegistersAmd64Linux.callerSaved, ...RegistersAmd64Linux.integerArguments, ...RegistersAmd64Linux.calleeSaved];
-
-        for (const register of registers)
+        for (const register of RegistersAmd64Linux.calleeSaved)
         {
             if (!this.registersInUse.has(register))
             {
-                // Save registers that must be saved by the callee:
-                if (RegistersAmd64Linux.calleeSaved.includes(register))
-                {
-                    const stackLocation = this.nextStackLocation;
-
-                    this.code.push(`mov ${stackLocation}, ${register.bit64}`);
-
-                    this.usedCalleeSavedRegisters.set(register, stackLocation);
-                }
+                const stackLocation = this.getLocation(variableSymbol);
 
                 this.registersInUse.add(register);
+                this.variableToRegister.set(variableSymbol, register);
 
-                return register;
-            }
-        }
+                // TODO: Save register!
 
-        return null;
-    }
+                const registerName = this.getRegisterNameForSize(register, variableSymbol.size);
 
-    protected freeVariable (variable: SemanticSymbols.Variable): void
-    {
-        for (const variableStack of this.variableStacks.slice().reverse())
-        {
-            const variableLocation = variableStack.get(variable);
-
-            if (variableLocation !== undefined)
-            {
-                variableStack.delete(variable);
-
-                if (variableLocation.location instanceof Register64Amd64)
-                {
-                    this.registersInUse.delete(variableLocation.location);
-                }
+                this.instructions.push(
+                    new Instructions.Instruction('mov', registerName, stackLocation),
+                );
 
                 return;
             }
         }
 
-        throw new Error(`Transpiler error: The given variable "${variable.name}" cannot be freed because it is unknown.`);
-    }
-
-    protected getVariableLocation (variable: SemanticSymbols.Variable): LocationedVariableAmd64
-    {
-        for (const variableStack of this.variableStacks.slice().reverse())
-        {
-            const variableLocation = variableStack.get(variable);
-
-            if (variableLocation !== undefined)
-            {
-                return variableLocation;
-            }
-        }
-
-        throw new Error(`Transpiler error: The given variable "${variable.name}" has no location.`);
-    }
-
-    protected moveVariableToRegister (locationedVariable: LocationedVariableAmd64): LocationedVariableAmd64
-    {
-        if (!(locationedVariable.location instanceof Register64Amd64))
-        {
-            const register = this.makeAnyRegisterFree();
-
-            // Move our stack variable into a register:
-            // TODO: Replace the hardcoded size with the real type size:
-            this.code.push(`mov ${register.bit64}, ${locationedVariable.locationString}`);
-            locationedVariable.location = register;
-        }
-
-        return locationedVariable;
-    }
-
-    private makeAnyRegisterFree (): Register64Amd64
-    {
-        let register = this.getNextFreeRegister();
-
-        if (register === null)
-        {
-            const locationedVariableInRegister = this.getAnyVariableInRegister();
-
-            register = locationedVariableInRegister.location as Register64Amd64;
-
-            const stackLocation = this.nextStackLocation;
-
-            // Move register variable to the stack:
-            this.code.push(`mov ${stackLocation}, ${locationedVariableInRegister.locationString}`);
-            locationedVariableInRegister.location = stackLocation;
-        }
-
-        return register;
-    }
-
-    private getAnyVariableInRegister (): LocationedVariableAmd64
-    {
-        for (const stack of this.variableStacks)
-        {
-            for (const locationedVariable of stack.values())
-            {
-                if (locationedVariable.location instanceof Register64Amd64)
-                {
-                    return locationedVariable;
-                }
-            }
-        }
-
-        throw new Error('Transpile error: There are no registers. How can this happen?');
+        /* TODO: This should not be able to happen as a maximum of two registers can be in use at the same time.
+                 But shouldn't this be a diagnostic error regardless? */
+        throw new Error('Transpiler error: No free register available.');
     }
 
     /**
-     * Save the currently in use caller saved registers before a function call.
-     * @param targetLocation The target location of the function call, for it to be ignored instead of saved.
-     * @param isSystemCall If true, the registers for a system call are saved instead of a normal function call.
+     * Unpins the given variable from its register.
+     * @param variableSymbol The variable to unpin.
+     * @param hasChanged True if the variable has been changed, false otherwise. Will save the variable to its stack location if true.
      */
-    protected saveRegistersForFunctionCall (targetLocation: LocationedVariableAmd64|undefined, isSystemCall = false): void
+    public unpinVariableFromRegister (variableSymbol: IntermediateSymbols.Variable, hasChanged = true): void
     {
-        const registersToSave: Set<Register64Amd64> = new Set<Register64Amd64>();
+        const register = this.variableToRegister.get(variableSymbol);
 
-        // NOTE: The order of the registers (i.e. the reverse of the restore registers function) is important!
-        if (isSystemCall)
+        if (register === undefined)
         {
-            for (const register of [...RegistersAmd64Linux.syscallArguments, ...RegistersAmd64Linux.syscallCallerSaved])
-            {
-                registersToSave.add(register);
-            }
-        }
-        else
-        {
-            registersToSave.add(RegistersAmd64Linux.integerReturn);
-
-            for (const register of [...RegistersAmd64Linux.integerArguments, ...RegistersAmd64Linux.callerSaved])
-            {
-                registersToSave.add(register);
-            }
+            throw new Error('Transpiler error: Tried to unpin a variable that has not been pinned.');
         }
 
-        // Do not save the target location if it is a register:
-        if (targetLocation?.location instanceof Register64Amd64)
+        this.variableToRegister.delete(variableSymbol);
+        this.registersInUse.delete(register);
+
+        // Save variable value to its stack location:
+        if (hasChanged)
         {
-            registersToSave.delete(targetLocation.location);
+            const registerName = this.getRegisterNameForSize(register, variableSymbol.size);
+
+            this.instructions.push(
+                new Instructions.Instruction('mov', this.getLocation(variableSymbol), registerName),
+            );
         }
 
-        const currentlySavedRegisters: Register64Amd64[] = [];
-
-        for (const register of registersToSave)
-        {
-            if (this.registersInUse.has(register))
-            {
-                this.code.push(`push ${register.bit64}`);
-
-                this.registersInUse.delete(register);
-
-                currentlySavedRegisters.push(register);
-            }
-        }
-
-        this.currentlySavedRegistersList.push(currentlySavedRegisters);
+        // TODO: Restore register!
     }
 
-    protected restoreRegistersAfterFunctionCall (): void
+    public getParameterLocation (parameter: IntermediateSymbols.Parameter): string
     {
-        const currentlySavedRegisters = this.currentlySavedRegistersList.pop();
+        const maxParameterCount = RegistersAmd64Linux.integerArguments.length;
 
-        if (currentlySavedRegisters === undefined)
+        if (parameter.index >= maxParameterCount)
         {
-            throw new Error('Transpiler error: Tried to restore registers after a function call without saving them.');
+            throw new Error(
+                `Transpiler error: Stack parameters are not supported. There must not be more than ${maxParameterCount} parameters.`
+            );
         }
 
-        // The currently saved registers list must be reversed to correctly pop the values into their registers:
-        currentlySavedRegisters.reverse();
+        const parameterRegister = RegistersAmd64Linux.integerArguments[parameter.index];
 
-        for (const register of currentlySavedRegisters)
+        const registerName = this.getRegisterNameForSize(parameterRegister, parameter.size);
+
+        return registerName;
+    }
+
+    public getReturnValueLocation (returnValue: IntermediateSymbols.ReturnValue): string
+    {
+        if (returnValue.index > 0)
         {
-            this.code.push(`pop ${register.bit64}`);
-
-            this.registersInUse.add(register);
+            throw new Error(
+                `Transpiler error: Multiple return values are not supported.`
+            );
         }
+
+        const returnRegister = RegistersAmd64Linux.integerReturn;
+
+        const registerName = this.getRegisterNameForSize(returnRegister, returnValue.size);
+
+        return registerName;
     }
 }

--- a/src/transpiler/amd64/linux/transpilerAmd64Linux.ts
+++ b/src/transpiler/amd64/linux/transpilerAmd64Linux.ts
@@ -1,484 +1,384 @@
-import * as SemanticNodes from '../../../connector/semanticNodes';
-import * as SemanticSymbols from '../../../connector/semanticSymbols';
-import { BuildInOperators } from '../../../definitions/buildInOperators';
-import { BuildInTypes } from '../../../definitions/buildInTypes';
-import { LocationedVariableAmd64 } from '../locationedVariableAmd64';
-import { LocationManagerAmd64Linux } from './locationManagerAmd64Linux';
-import { RegistersAmd64Linux } from './registersAmd64Linux';
-import { SemanticKind } from '../../../connector/semanticKind';
-import { SemanticTreeTranspiler } from '../../semanticTreeTranspiler';
+import * as Instructions from '../../common/instructions';
+import * as Intermediates from '../../../lowerer/intermediates';
+import { DirectiveInstruction } from './directiveInstruction';
+import { IntermediateKind } from '../../../lowerer/intermediateKind';
+import { IntermediateSymbolKind } from '../../../lowerer/intermediateSymbolKind';
+import { LocationManagerAmd64LinuxNone } from './locationManagerAmd64Linux';
 import { TextEncoder } from 'node:util';
+import { Transpiler } from '../../transpiler';
 
-export class TranspilerAmd64Linux extends LocationManagerAmd64Linux implements SemanticTreeTranspiler
+export class TranspilerAmd64Linux implements Transpiler
 {
-    protected code: string[];
-    private constantCode: string[];
+    private instructions: Instructions.Instruction[];
 
-    private localLabelCounter: number;
-
-    private get nextLocalLabel (): string
-    {
-        const newLocalLabel = `.l#${this.localLabelCounter}`;
-
-        this.localLabelCounter++;
-
-        return newLocalLabel;
-    }
-
-    /**
-     * A counter for generating unqiue constant IDs.
-     */
-    private constantCounter: number;
-
-    private importedFunctions: Set<SemanticSymbols.Function>;
+    private locationManager: LocationManagerAmd64LinuxNone;
 
     constructor ()
     {
-        super();
+        this.instructions = [];
 
-        this.code = [];
-        this.constantCode = [];
-        this.constantCounter = 0;
-        this.localLabelCounter = 0;
-        this.importedFunctions = new Set<SemanticSymbols.Function>();
+        this.locationManager = new LocationManagerAmd64LinuxNone(this.instructions);
     }
 
-    public run (semanticTree: SemanticNodes.File): string
+    public run (fileIntermediate: Intermediates.File): string
     {
-        this.code = [];
-        this.constantCode = [];
-        this.constantCounter = 0;
-        this.localLabelCounter = 0;
-        this.importedFunctions.clear();
+        this.transpileFile(fileIntermediate);
 
-        const assembly: string[] = [];
-
-        this.transpileFile(semanticTree);
-
-        assembly.push('[section .rodata]');
-
-        assembly.push(...this.constantCode);
-
-        assembly.push('[section .text]');
-
-        // All imported functions must be marked as extern to be found by the Assembler:
-        for (const importedFunction of this.importedFunctions)
-        {
-            assembly.push(`[extern ${importedFunction.name}]`);
-        }
-
-        assembly.push(
-            '[extern exit]',
+        this.instructions.push(
+            new DirectiveInstruction('extern', 'exit'),
             // The start routine calls main and then exits properly:
-            '[global _start]',
-            '_start:',
-            'call main',
-            'call exit',
+            new DirectiveInstruction('global', '_start'),
+            new Instructions.Label('_start'),
+            new Instructions.Instruction('call', 'main'),
+            new Instructions.Instruction('call', 'exit'),
         );
 
-        assembly.push(...this.code);
+        const fileAssembly = this.convertInstructionsToAssembly(this.instructions);
 
-        const result = assembly.join("\n") + "\n";
+        this.instructions = [];
 
-        return result;
+        return fileAssembly;
     }
 
-    private transpileFile (fileNode: SemanticNodes.File): void
+    private convertInstructionsToAssembly (instructions: Instructions.Instruction[]): string
     {
-        for (const importNode of fileNode.imports)
+        /** Render options for simple NASM Assembly statements */
+        const statementRenderOptions: Instructions.RenderOptions = {
+            commandOperandSplitter: ' ',
+            operandSplitter: ', ',
+            prefix: '',
+            postfix: '',
+        };
+
+        let assembly = '';
+
+        for (const instruction of instructions)
         {
-            this.transpileFile(importNode.file);
+            assembly += instruction.render(statementRenderOptions) + '\n';
         }
 
-        for (const functionNode of fileNode.functions)
+        return assembly;
+    }
+
+    private transpileFile (fileIntermediate: Intermediates.File): void
+    {
+        this.instructions.push(
+            new DirectiveInstruction('section', '.rodata'),
+        );
+
+        for (const constantIntermediate of fileIntermediate.constants)
         {
-            this.transpileFunction(functionNode);
+            this.transpileConstant(constantIntermediate);
+        }
+
+        this.instructions.push(
+            new DirectiveInstruction('section', '.text'),
+        );
+
+        for (const externalIntermediate of fileIntermediate.externals)
+        {
+            this.transpileExternal(externalIntermediate);
+        }
+
+        for (const functionIntermediate of fileIntermediate.functions)
+        {
+            this.transpileFunction(functionIntermediate);
         }
     }
 
-    private transpileFunction (functionNode: SemanticNodes.FunctionDeclaration): void
+    private transpileConstant (constantIntermediate: Intermediates.Constant): void
     {
-        if (functionNode.symbol.isExternal)
+        // TODO: For now, constants are strings. This might change in the future.
+
+        const constantValue = constantIntermediate.symbol.value;
+
+        // We need an encoded string to get the real byte count:
+        const encoder = new TextEncoder();
+        const encodedString = encoder.encode(constantValue);
+
+        const constantId = constantIntermediate.symbol.name;
+        const constantLength = encodedString.length;
+
+        // The string is a byte array prefixed with it's (platform dependent) length:
+        this.instructions.push(
+            new Instructions.Label(constantId),
+            new Instructions.Instruction('dq', `${constantLength}`),
+            new Instructions.Instruction('db', `'${constantValue}'`),
+        );
+    }
+
+    private transpileExternal (externalIntermediate: Intermediates.External): void
+    {
+        this.instructions.push(
+            new DirectiveInstruction('extern', `${externalIntermediate.symbol.name}`),
+        );
+    }
+
+    private transpileFunction (functionIntermediate: Intermediates.Function): void
+    {
+        this.instructions.push(
+            new Instructions.Label(functionIntermediate.symbol.name),
+        );
+
+        this.locationManager.enterFunction();
+
+        for (const instruction of functionIntermediate.body)
         {
-            return;
+            this.transpileStatement(instruction);
         }
+    }
 
-        this.code.push(functionNode.symbol.name + ':'); // Function name
-
-        // Save base pointer:
-        this.code.push(`push ${RegistersAmd64Linux.stackBasePointer.bit64}`);
-        // Set base pointer to current stack pointer:
-        this.code.push(`mov ${RegistersAmd64Linux.stackBasePointer.bit64}, ${RegistersAmd64Linux.stackPointer.bit64}`);
-
-        this.addNewVariableStack(true);
-
-        let parameterCounter = 0;
-        for (const parameter of functionNode.symbol.parameters)
+    private transpileStatement (statementIntermediate: Intermediates.Statement): void
+    {
+        switch (statementIntermediate.kind)
         {
-            if (parameterCounter >= RegistersAmd64Linux.integerArguments.length)
+            case IntermediateKind.Add:
+                this.transpileAdd(statementIntermediate);
+                break;
+            case IntermediateKind.Call:
+                this.transpileCall(statementIntermediate);
+                break;
+            case IntermediateKind.Compare:
+                this.transpileCompare(statementIntermediate);
+                break;
+            case IntermediateKind.Dismiss:
+                this.transpileDismiss(statementIntermediate);
+                break;
+            case IntermediateKind.Give:
+                this.transpileGive(statementIntermediate);
+                break;
+            case IntermediateKind.Goto:
+                this.transpileGoto(statementIntermediate);
+                break;
+            case IntermediateKind.Introduce:
+                this.transpileIntroduce(statementIntermediate);
+                break;
+            case IntermediateKind.JumpIfEqual:
+                this.transpileJumpIfEqual(statementIntermediate);
+                break;
+            case IntermediateKind.JumpIfGreater:
+                this.transpileJumpIfGreater(statementIntermediate);
+                break;
+            case IntermediateKind.JumpIfLess:
+                this.transpileJumpIfLess(statementIntermediate);
+                break;
+            case IntermediateKind.Label:
+                this.transpileLabel(statementIntermediate);
+                break;
+            case IntermediateKind.Move:
+                this.transpileMove(statementIntermediate);
+                break;
+            case IntermediateKind.Negate:
+                this.transpileNegate(statementIntermediate);
+                break;
+            case IntermediateKind.Return:
+                this.transpileReturn();
+                break;
+            case IntermediateKind.Subtract:
+                this.transpileSubtract(statementIntermediate);
+                break;
+            case IntermediateKind.Take:
+                this.transpileTake(statementIntermediate);
+                break;
+        }
+    }
+
+    private transpileAdd (addIntermediate: Intermediates.Add): void
+    {
+        this.locationManager.pinVariableToRegister(addIntermediate.leftOperand);
+
+        const leftOperandLocation = this.locationManager.getLocation(addIntermediate.leftOperand);
+        const rightOperandLocation = this.locationManager.getLocation(addIntermediate.rightOperand);
+
+        this.instructions.push(
+            new Instructions.Instruction('add', leftOperandLocation, rightOperandLocation),
+        );
+
+        this.locationManager.unpinVariableFromRegister(addIntermediate.leftOperand);
+    }
+
+    private transpileCall (callIntermediate: Intermediates.Call): void
+    {
+        this.instructions.push(
+            new Instructions.Instruction('call', callIntermediate.functionSymbol.name),
+        );
+    }
+
+    private transpileCompare (compareIntermediate: Intermediates.Compare): void
+    {
+        this.locationManager.pinVariableToRegister(compareIntermediate.leftOperand);
+
+        const leftOperandLocation = this.locationManager.getLocation(compareIntermediate.leftOperand);
+        const rightOperandLocation = this.locationManager.getLocation(compareIntermediate.rightOperand);
+
+        this.instructions.push(
+            new Instructions.Instruction('cmp', leftOperandLocation, rightOperandLocation),
+        );
+
+        this.locationManager.unpinVariableFromRegister(compareIntermediate.leftOperand, false);
+    }
+
+    private transpileDismiss (dismissIntermediate: Intermediates.Dismiss): void
+    {
+        this.locationManager.dismiss(dismissIntermediate.variableSymbol);
+    }
+
+    private transpileGive (giveIntermediate: Intermediates.Give): void
+    {
+        switch (giveIntermediate.targetSymbol.kind)
+        {
+            case IntermediateSymbolKind.Parameter:
             {
-                throw new Error('Transpiler error: Stack parameters are not supported.');
+                const parameterLocation = this.locationManager.getParameterLocation(giveIntermediate.targetSymbol);
+                const variableLocation = this.locationManager.getLocation(giveIntermediate.variable);
+
+                this.instructions.push(
+                    new Instructions.Instruction('mov', parameterLocation, variableLocation),
+                );
+
+                break;
             }
+            case IntermediateSymbolKind.ReturnValue:
+            {
+                const returnLocation = this.locationManager.getReturnValueLocation(giveIntermediate.targetSymbol);
+                const variableLocation = this.locationManager.getLocation(giveIntermediate.variable);
 
-            const register = RegistersAmd64Linux.integerArguments[parameterCounter];
-            parameterCounter++;
+                this.instructions.push(
+                    new Instructions.Instruction('mov', returnLocation, variableLocation),
+                );
 
-            this.pushVariable(parameter, register);
-        }
-
-        if (functionNode.section === null)
-        {
-            throw new Error('Transpiler error: The section of a non-external function is null.');
-        }
-
-        this.transpileSection(functionNode.section);
-
-        this.removeLastVariableStack(true);
-    }
-
-    private transpileSection (sectionNode: SemanticNodes.Section): void
-    {
-        this.addNewVariableStack();
-
-        for (const statement of sectionNode.statements)
-        {
-            this.transpileStatement(statement);
-        }
-
-        this.removeLastVariableStack();
-    }
-
-    private transpileStatement (statementNode: SemanticNodes.SemanticNode): void
-    {
-        switch (statementNode.kind)
-        {
-            case SemanticKind.Section:
-                this.transpileSection(statementNode as SemanticNodes.Section);
                 break;
-            case SemanticKind.VariableDeclaration:
-                this.transpileVariableDeclaration(statementNode as SemanticNodes.VariableDeclaration);
-                break;
-            case SemanticKind.ReturnStatement:
-                this.transpileReturnStatement(statementNode as SemanticNodes.ReturnStatement);
-                break;
-            case SemanticKind.Assignment:
-                this.transpileAssignment(statementNode as SemanticNodes.Assignment);
-                break;
-            case SemanticKind.Label:
-                this.transpileLabel(statementNode as SemanticNodes.Label);
-                break;
-            case SemanticKind.GotoStatement:
-                this.transpileGotoStatement(statementNode as SemanticNodes.GotoStatement);
-                break;
-            case SemanticKind.ConditionalGotoStatement:
-                this.transpileConditionalGotoStatement(statementNode as SemanticNodes.ConditionalGotoStatement);
-                break;
-            default:
-                this.transpileExpression(statementNode as SemanticNodes.Expression);
+            }
         }
     }
 
-    private transpileVariableDeclaration (variableDeclarationNode: SemanticNodes.VariableDeclaration): void
+    private transpileGoto (gotoIntermediate: Intermediates.Goto): void
     {
-        const variableLocation = this.pushVariable(variableDeclarationNode.symbol);
-
-        if (variableDeclarationNode.initialiser !== null)
-        {
-            this.transpileExpression(variableDeclarationNode.initialiser, variableLocation);
-        }
-    }
-
-    private transpileReturnStatement (returnStatementNode: SemanticNodes.ReturnStatement): void
-    {
-        if (returnStatementNode.expression !== null)
-        {
-            const temporaryVariable = new SemanticSymbols.Variable('return', returnStatementNode.expression.type, false);
-            const temporaryLocationedVariable = new LocationedVariableAmd64(temporaryVariable, RegistersAmd64Linux.integerReturn);
-
-            // TODO: Replace hard coded return register with actual type and size:
-            this.transpileExpression(returnStatementNode.expression, temporaryLocationedVariable);
-        }
-
-        this.code.push(
-            'leave',
-            'ret',
+        this.instructions.push(
+            new Instructions.Instruction('jmp', gotoIntermediate.target.name),
         );
     }
 
-    private transpileAssignment (assignmentNode: SemanticNodes.Assignment): void
+    private transpileIntroduce (introduceIntermediate: Intermediates.Introduce): void
     {
-        const variableLocation = this.getVariableLocation(assignmentNode.variable);
-
-        this.transpileExpression(assignmentNode.expression, variableLocation);
+        this.locationManager.introduce(introduceIntermediate.variableSymbol);
     }
 
-    private transpileLabel (labelNode: SemanticNodes.Label): void
+    private transpileJumpIfEqual (jumpIfEqualIntermediate: Intermediates.JumpIfEqual): void
+    {
+        this.instructions.push(
+            new Instructions.Instruction('je', jumpIfEqualIntermediate.target.name),
+        );
+    }
+
+    private transpileJumpIfGreater (jumpIfGreaterIntermediate: Intermediates.JumpIfGreater): void
+    {
+        this.instructions.push(
+            new Instructions.Instruction('jg', jumpIfGreaterIntermediate.target.name),
+        );
+    }
+
+    private transpileJumpIfLess (jumpIfLessIntermediate: Intermediates.JumpIfLess): void
+    {
+        this.instructions.push(
+            new Instructions.Instruction('jl', jumpIfLessIntermediate.target.name),
+        );
+    }
+
+    private transpileLabel (labelIntermediate: Intermediates.Label): void
     {
         // TODO: Should we make the labels "local labels" starting with a point?
-        this.code.push(`${labelNode.symbol.name}:`);
+        this.instructions.push(
+            new Instructions.Label(labelIntermediate.symbol.name),
+        );
     }
 
-    private transpileGotoStatement (gotoStatementNode: SemanticNodes.GotoStatement): void
+    private transpileMove (moveIntermediate: Intermediates.Move): void
     {
-        this.code.push(`jmp ${gotoStatementNode.labelSymbol.name}`);
-    }
+        this.locationManager.pinVariableToRegister(moveIntermediate.to);
 
-    private transpileConditionalGotoStatement (conditionalGotoStatement: SemanticNodes.ConditionalGotoStatement): void
-    {
-        const conditionResultTemporaryVariable = new SemanticSymbols.Variable('', conditionalGotoStatement.condition.type, false);
+        let fromLocation: string;
 
-        const conditionResultLocation = this.pushVariable(conditionResultTemporaryVariable);
+        switch (moveIntermediate.from.kind)
+        {
+            case IntermediateSymbolKind.Constant:
+                fromLocation = moveIntermediate.from.name;
+                break;
+            case IntermediateSymbolKind.Literal:
+                fromLocation = moveIntermediate.from.value;
+                break;
+            case IntermediateSymbolKind.Variable:
+                fromLocation = this.locationManager.getLocation(moveIntermediate.from);
+                break;
+        }
 
-        // Transpile the condition with the condition result location as target location:
-        this.transpileExpression(conditionalGotoStatement.condition, conditionResultLocation);
+        const toLocation = this.locationManager.getLocation(moveIntermediate.to);
 
-        // Go sure the variable is on the register because we need a register for comparisons:
-        this.moveVariableToRegister(conditionResultLocation);
-
-        const compareValue = conditionalGotoStatement.conditionResult ? '1' : '0';
-
-        this.code.push(
-            `cmp ${conditionResultLocation.locationString}, ${compareValue}`,
-            `je ${conditionalGotoStatement.labelSymbol.name}`,
+        this.instructions.push(
+            new Instructions.Instruction('mov', toLocation, fromLocation),
         );
 
-        this.freeVariable(conditionResultTemporaryVariable);
+        this.locationManager.unpinVariableFromRegister(moveIntermediate.to);
     }
 
-    private transpileExpression (expressionNode: SemanticNodes.Expression, targetLocation?: LocationedVariableAmd64): void
+    private transpileNegate (negateIntermediate: Intermediates.Negate): void
     {
-        if (targetLocation === undefined)
-        {
-            switch (expressionNode.kind)
-            {
-                // TODO: Move this to the statement transpilation.
+        const operandLocation = this.locationManager.getLocation(negateIntermediate.operand);
 
-                case SemanticKind.CallExpression:
-                    this.transpileCallExpression(expressionNode as SemanticNodes.CallExpression);
-                    break;
-                default:
-                    throw new Error(`Transpile error: The expression of kind "${expressionNode.kind}" cannot be used as a statement.`);
-            }
-        }
-        else
-        {
-            switch (expressionNode.kind)
-            {
-                case SemanticKind.LiteralExpression:
-                    this.transpileLiteralExpression(expressionNode as SemanticNodes.LiteralExpression, targetLocation);
-                    break;
-                case SemanticKind.VariableExpression:
-                    this.transpileVariableExpression(expressionNode as SemanticNodes.VariableExpression, targetLocation);
-                    break;
-                case SemanticKind.CallExpression:
-                    this.transpileCallExpression(expressionNode as SemanticNodes.CallExpression, targetLocation);
-                    break;
-                case SemanticKind.UnaryExpression:
-                    this.transpileUnaryExpression(expressionNode as SemanticNodes.UnaryExpression, targetLocation);
-                    break;
-                case SemanticKind.BinaryExpression:
-                    this.transpileBinaryExpression(expressionNode as SemanticNodes.BinaryExpression, targetLocation);
-                    break;
-                default:
-                    throw new Error(`Transpiler error: No implementation for expression of kind "${expressionNode.kind}"`);
-            }
-        }
+        this.instructions.push(
+            new Instructions.Instruction('neg', operandLocation),
+        );
     }
 
-    private transpileLiteralExpression (literalExpression: SemanticNodes.LiteralExpression, targetLocation: LocationedVariableAmd64): void
+    private transpileReturn (): void
     {
-        switch (literalExpression.type)
+        this.locationManager.leaveFunction();
+
+        this.instructions.push(
+            new Instructions.Instruction('ret'),
+        );
+    }
+
+    private transpileSubtract (subtractIntermediate: Intermediates.Subtract): void
+    {
+        this.locationManager.pinVariableToRegister(subtractIntermediate.leftOperand);
+
+        const leftOperandLocation = this.locationManager.getLocation(subtractIntermediate.leftOperand);
+        const rightOperandLocation = this.locationManager.getLocation(subtractIntermediate.rightOperand);
+
+        this.instructions.push(
+            new Instructions.Instruction('sub', leftOperandLocation, rightOperandLocation),
+        );
+
+        this.locationManager.unpinVariableFromRegister(subtractIntermediate.leftOperand);
+    }
+
+    private transpileTake (takeIntermediate: Intermediates.Take): void
+    {
+        switch (takeIntermediate.takableValue.kind)
         {
-            case BuildInTypes.int:
-                this.code.push(`mov ${targetLocation.locationString}, ${literalExpression.value}`);
-                break;
-            case BuildInTypes.bool:
+            case IntermediateSymbolKind.Parameter:
             {
-                let value: string;
+                const parameterLocation = this.locationManager.getParameterLocation(takeIntermediate.takableValue);
+                const variableLocation = this.locationManager.getLocation(takeIntermediate.variableSymbol);
 
-                if (literalExpression.value === 'true')
-                {
-                    value = '1';
-                }
-                else if (literalExpression.value === 'false')
-                {
-                    value = '0';
-                }
-                else
-                {
-                    throw new Error(`Transpiler error: Unknown Bool value of "${literalExpression.value}"`);
-                }
-
-                this.code.push(`mov ${targetLocation.locationString}, ${value}`);
-
-                break;
-            }
-            case BuildInTypes.string:
-            {
-                // We need an encoded string to get the real byte count:
-                const encoder = new TextEncoder();
-                const encodedString = encoder.encode(literalExpression.value);
-
-                const constantLength = encodedString.length;
-
-                const constantId = `c#${this.constantCounter}`;
-                this.constantCounter++;
-
-                // The string is a byte array prefixed with it's (platform dependent) length:
-                this.constantCode.push(
-                    `${constantId}:`,
-                    `dq ${constantLength}`,
-                    `db '${literalExpression.value}'`,
-                );
-
-                this.code.push(
-                    `mov ${targetLocation.locationString}, ${constantId}`,
+                this.instructions.push(
+                    new Instructions.Instruction('mov', variableLocation, parameterLocation),
                 );
 
                 break;
             }
-            default:
-                throw new Error(`Transpiler error: Unknown literal of type "${literalExpression.type.name}".`);
-        }
-    }
-
-    private transpileVariableExpression (variableExpression: SemanticNodes.VariableExpression, targetLocation: LocationedVariableAmd64): void
-    {
-        const variableLocation = this.getVariableLocation(variableExpression.variable);
-
-        if (targetLocation.location !== variableLocation.location)
-        {
-            this.code.push(`mov ${targetLocation.locationString}, ${variableLocation.locationString}`);
-        }
-    }
-
-    private transpileCallExpression (callExpression: SemanticNodes.CallExpression, targetLocation?: LocationedVariableAmd64): void
-    {
-        this.saveRegistersForFunctionCall(targetLocation);
-
-        let argumentCounter = 0;
-        for (const argument of callExpression.arguments)
-        {
-            if (argumentCounter >= RegistersAmd64Linux.integerArguments.length)
+            case IntermediateSymbolKind.ReturnValue:
             {
-                throw new Error('Transpiler error: Stack arguments are not supported.');
-            }
+                const returnLocation = this.locationManager.getReturnValueLocation(takeIntermediate.takableValue);
+                const variableLocation = this.locationManager.getLocation(takeIntermediate.variableSymbol);
 
-            const register = RegistersAmd64Linux.integerArguments[argumentCounter];
-
-            // The arguments will be treated as temporary variables:
-            const locationedArgument = this.pushVariable(callExpression.functionSymbol.parameters[argumentCounter], register, true);
-
-            // The argument is an expression that must be placed into the register for this parameter:
-            this.transpileExpression(argument, locationedArgument);
-
-            argumentCounter++;
-        }
-
-        this.code.push(`call ${callExpression.functionSymbol.name}`);
-
-        // We must free the temporary variables again after the function call:
-        for (const parameter of callExpression.functionSymbol.parameters)
-        {
-            this.freeVariable(parameter);
-        }
-
-        this.restoreRegistersAfterFunctionCall();
-
-        if ((targetLocation !== undefined) && (targetLocation.location !== RegistersAmd64Linux.integerReturn))
-        {
-            // TODO: Replace hard coded return register with actual type and size:
-            this.code.push(`mov ${targetLocation.locationString}, ${RegistersAmd64Linux.integerReturn.bit64}`);
-        }
-
-        if (callExpression.functionSymbol.isExternal)
-        {
-            this.importedFunctions.add(callExpression.functionSymbol);
-        }
-    }
-
-    private transpileUnaryExpression (unaryExpression: SemanticNodes.UnaryExpression, targetLocation: LocationedVariableAmd64): void
-    {
-        this.transpileExpression(unaryExpression.operand, targetLocation);
-
-        const operator = unaryExpression.operator;
-
-        switch (operator)
-        {
-            case BuildInOperators.unaryIntAddition:
-                // An unary addition has no effect.
-                break;
-            case BuildInOperators.unaryIntSubtraction:
-                this.moveVariableToRegister(targetLocation);
-                this.code.push(`neg ${targetLocation.locationString}`);
-                break;
-            default:
-                throw new Error(
-                    `Transpiler error: The operator "${operator.kind}" for operand of "${operator.operandType.name}" and ` +
-                    `result of "${operator.resultType.name}" is not implemented.`
-                );
-        }
-    }
-
-    private transpileBinaryExpression (binaryExpression: SemanticNodes.BinaryExpression, targetLocation: LocationedVariableAmd64): void
-    {
-        const operator = binaryExpression.operator;
-
-        // Temporary variable for the right operand:
-        const temporaryVariable = new SemanticSymbols.Variable('', binaryExpression.rightOperand.type, false);
-        const temporaryVariableLocation = this.pushVariable(temporaryVariable);
-
-        this.transpileExpression(binaryExpression.leftOperand, targetLocation);
-        this.transpileExpression(binaryExpression.rightOperand, temporaryVariableLocation);
-
-        this.moveVariableToRegister(targetLocation);
-
-        switch (operator)
-        {
-            case BuildInOperators.binaryIntAddition:
-                this.code.push(`add ${targetLocation.locationString}, ${temporaryVariableLocation.locationString}`);
-                break;
-            case BuildInOperators.binaryIntSubtraction:
-                this.code.push(`sub ${targetLocation.locationString}, ${temporaryVariableLocation.locationString}`);
-                break;
-            case BuildInOperators.binaryIntEqual:
-            case BuildInOperators.binaryIntLess:
-            case BuildInOperators.binaryIntGreater:
-            {
-                let operatorInstruction = 'je'; // BuildInOperators.binaryIntEqual
-
-                switch (operator)
-                {
-                    case BuildInOperators.binaryIntLess:
-                        operatorInstruction = 'jl';
-                        break;
-                    case BuildInOperators.binaryIntGreater:
-                        operatorInstruction = 'jg';
-                        break;
-                }
-
-                const trueLabel = this.nextLocalLabel;
-                const endLabel = this.nextLocalLabel;
-
-                this.code.push(
-                    `cmp ${targetLocation.locationString}, ${temporaryVariableLocation.locationString}`,
-                    `${operatorInstruction} ${trueLabel}`,
-                    `mov ${targetLocation.locationString}, 0`,
-                    `jmp ${endLabel}`,
-                    `${trueLabel}:`,
-                    `mov ${targetLocation.locationString}, 1`,
-                    `${endLabel}:`,
+                this.instructions.push(
+                    new Instructions.Instruction('mov', variableLocation, returnLocation),
                 );
 
                 break;
             }
-            default:
-                throw new Error(
-                    `Transpiler error: The operator "${operator.kind}" for the operands of "${operator.leftType.name}" and ` +
-                    `"${operator.rightType.name}" with the result type of "${operator.resultType.name}" is not implemented.`
-                );
         }
-
-        this.freeVariable(temporaryVariable);
     }
 }


### PR DESCRIPTION
Note that the old optimising location manager has been replaced with a simple non optimising one. It will put everything onto the stack and only use registers where needed.
Furthermore, the transpiler itself is simpler than before. Besides the intended simplification by using the intermediate representation, it produces "dumper" code for now, for example in comparisons where there is an especially unnecessary conversion and variable introduction. For a debug build this is okay, but maybe there could be a big improvement by removing these inefficiencies.

This closes #9.