### PR TITLE
Array support

### DIFF
--- a/examples/array/main.ph
+++ b/examples/array/main.ph
@@ -1,0 +1,28 @@
+import Standard.Conversion;
+import Standard.Io;
+
+module ArrayExample;
+
+function main ()
+{
+    let myArray := new Array[Integer](3);
+    myArray.set(0, 1);
+    myArray.set(1, 2);
+    myArray.set(2, 3);
+
+    let length := myArray.length;
+    let lengthString := Conversion.intToString(length);
+    Io.writeLine('Array length:');
+    Io.writeLine(lengthString);
+
+    Io.writeLine('Array elements:');
+
+    let variable index := 0;
+    while index < 3
+    {
+        let gotElement := myArray.get(index);
+        let gotString := Conversion.intToString(gotElement);
+        Io.writeLine(gotString);
+        index := index + 1;
+    }
+}

--- a/examples/arrayOfObjects/main.ph
+++ b/examples/arrayOfObjects/main.ph
@@ -1,0 +1,45 @@
+import Standard.Conversion;
+import Standard.Io;
+import ArrayOfObjectsExample.MyClass;
+
+module ArrayOfObjectsExample;
+
+function main ()
+{
+    let myArray := new Array[MyClass](3);
+    myArray.set(0, new MyClass());
+    myArray.set(1, new MyClass());
+    myArray.set(2, new MyClass());
+
+    let firstObject := myArray.get(0);
+    firstObject.setIndex(0);
+    firstObject.setMessage('First element');
+    let secondObject := myArray.get(1);
+    secondObject.setIndex(1);
+    secondObject.setMessage('Second element');
+    let thirdObject := myArray.get(2);
+    thirdObject.setIndex(2);
+    thirdObject.setMessage('Third element');
+
+    let length := myArray.length;
+    let lengthString := Conversion.intToString(length);
+    Io.writeLine('Array length:');
+    Io.writeLine(lengthString);
+
+    Io.writeLine('Array elements:');
+
+    let variable index := 0;
+    while index < 3
+    {
+        let theObject := myArray.get(index);
+
+        let objectIndex := theObject.getIndex();
+        let objectMessage := theObject.getMessage();
+
+        let objectIndexString := Conversion.intToString(objectIndex);
+        Io.writeLine(objectIndexString);
+        Io.writeLine(objectMessage);
+
+        index := index + 1;
+    }
+}

--- a/examples/arrayOfObjects/myClass.ph
+++ b/examples/arrayOfObjects/myClass.ph
@@ -1,0 +1,24 @@
+class ArrayOfObjectsExample.MyClass;
+
+field variable index: Integer := 0;
+field variable message: String := 'Message';
+
+method setIndex (newIndex: Integer)
+{
+    index := newIndex;
+}
+
+method getIndex (): Integer
+{
+    return index;
+}
+
+method setMessage (newMessage: String)
+{
+    message := newMessage;
+}
+
+method getMessage (): String
+{
+    return message;
+}

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -331,6 +331,37 @@ export class Connector
     {
         const typeName = typeSyntaxNode.identifier.content;
 
+        if (BuildInTypes.isArrayName(typeName))
+        {
+            if (typeSyntaxNode.arguments.elements.length !== 1)
+            {
+                this.diagnostic.throw(
+                    new Diagnostic.Error(
+                        `The type "${typeName}" requires exactly one type argument.`,
+                        Diagnostic.Codes.WrongGenericArgumentCountError,
+                        typeSyntaxNode.identifier
+                    )
+                );
+            }
+
+            const elementTypeSyntax = typeSyntaxNode.arguments.elements[0];
+
+            if (elementTypeSyntax.kind !== SyntaxKind.Type)
+            {
+                this.diagnostic.throw(
+                    new Diagnostic.Error(
+                        `The generic argument of type "${typeName}" must be a type.`,
+                        Diagnostic.Codes.GenericArgumentMustBeTypeError,
+                        elementTypeSyntax.token ?? typeSyntaxNode.identifier
+                    )
+                );
+            }
+
+            const elementType = this.connectType(elementTypeSyntax, context);
+
+            return BuildInTypes.createSemanticArrayType(elementType);
+        }
+
         let type: SemanticSymbols.TypeLike|SemanticSymbols.GenericType|null = BuildInTypes.getTypeByName(typeName);
 
         if (type === null)
@@ -738,7 +769,7 @@ export class Connector
             {
                 const accessExpression = this.connectAccessExpression(statement, context);
 
-                if (accessExpression.kind === SemanticKind.CallExpression)
+                if (accessExpression.kind === SemanticKind.CallExpression || accessExpression.kind === SemanticKind.ArraySetExpression)
                 {
                     return accessExpression;
                 }
@@ -1059,31 +1090,162 @@ export class Connector
                 )
             );
         }
-        else if (type.kind === SemanticSymbolKind.GenericType)
-        {
-            throw new Error('Connector error: Generic literals, how should that work?');
-        }
-
         return new SemanticNodes.LiteralExpression(value, type);
     }
 
     private connectInstantiationExpression (
         expression: SyntaxNodes.InstantiationExpression,
         context: FunctionContext|ModuleContext
-    ): SemanticNodes.InstantiationExpression
+    ): SemanticNodes.InstantiationExpression|SemanticNodes.ArrayInstantiationExpression
     {
         const type = this.connectType(expression.type, context);
 
-        const elements: SemanticNodes.Expression[] = [];
-        for (const element of expression.arguments.elements)
+        if (BuildInTypes.isArray(type))
         {
-            const connectedExpression = this.connectExpression(element, context);
-            elements.push(connectedExpression);
+            if (type.kind !== SemanticSymbolKind.ConcreteType)
+            {
+                throw new Error('Connector error: Array type must be a concrete type with parameters.');
+            }
 
-            // TODO: As soon as there is a constructor, we must check the arguments' types here.
+            return this.connectArrayInstantiation(expression, type, context);
+        }
+        else
+        {
+            const elements: SemanticNodes.Expression[] = [];
+            for (const element of expression.arguments.elements)
+            {
+                const connectedExpression = this.connectExpression(element, context);
+                elements.push(connectedExpression);
+
+                // TODO: As soon as there is a constructor, we must check the arguments' types here.
+            }
+
+            return new SemanticNodes.InstantiationExpression(type, elements);
+        }
+    }
+
+    private connectArrayInstantiation (
+        expression: SyntaxNodes.InstantiationExpression,
+        arrayType: SemanticSymbols.ConcreteType,
+        context: FunctionContext|ModuleContext
+    ): SemanticNodes.ArrayInstantiationExpression
+    {
+        if (expression.arguments.elements.length !== 1)
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    'Array constructor requires exactly one argument (size).',
+                    Diagnostic.Codes.WrongArgumentCountError,
+                    expression.opening
+                )
+            );
         }
 
-        return new SemanticNodes.InstantiationExpression(type, elements);
+        const sizeArgument = this.connectExpression(expression.arguments.elements[0], context);
+
+        if (!sizeArgument.type.equals(BuildInTypes.integer)) // TODO: Should be Cardinal.
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    `Array size must be of type ${BuildInTypes.integer.namespace.baseName}.`,
+                    Diagnostic.Codes.WrongArgumentTypeError,
+                    expression.opening
+                )
+            );
+        }
+
+        const elementType = BuildInTypes.getArrayElementType(arrayType);
+        if (elementType === null)
+        {
+            throw new Error('Connector error: Array type has no element type.');
+        }
+
+        return new SemanticNodes.ArrayInstantiationExpression(arrayType, elementType, sizeArgument);
+    }
+
+    private connectArrayGet (
+        arrayExpression: SemanticNodes.Expression,
+        argumentsList: ElementsList<SyntaxNodes.Expression>,
+        elementType: SemanticSymbols.TypeLike,
+        context: FunctionContext|ModuleContext
+    ): SemanticNodes.ArrayGetExpression
+    {
+        if (argumentsList.elements.length !== 1)
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    'Array.get requires exactly one argument (index).',
+                    Diagnostic.Codes.WrongArgumentCountError
+                    // TODO: Line information
+                )
+            );
+        }
+
+        const indexExpression = this.connectExpression(argumentsList.elements[0], context);
+
+        if (!indexExpression.type.equals(BuildInTypes.integer)) // TODO: Should be Cardinal.
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    `Array index must be of type ${BuildInTypes.integer.namespace.baseName}.`,
+                    Diagnostic.Codes.WrongArgumentTypeError
+                    // TODO: Line information
+                )
+            );
+        }
+
+        return new SemanticNodes.ArrayGetExpression(elementType, arrayExpression, indexExpression);
+    }
+
+    private connectArraySet (
+        arrayExpression: SemanticNodes.Expression,
+        argumentsList: ElementsList<SyntaxNodes.Expression>,
+        elementType: SemanticSymbols.TypeLike,
+        context: FunctionContext|ModuleContext
+    ): SemanticNodes.ArraySetExpression
+    {
+        if (argumentsList.elements.length !== 2)
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    'Array.set requires exactly two arguments (index, value).',
+                    Diagnostic.Codes.WrongArgumentCountError
+                    // TODO: Line information
+                )
+            );
+        }
+
+        const indexExpression = this.connectExpression(argumentsList.elements[0], context);
+        const valueExpression = this.connectExpression(argumentsList.elements[1], context);
+
+        if (!indexExpression.type.equals(BuildInTypes.integer)) // TODO: Should be Cardinal.
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    `Array index must be of type ${BuildInTypes.integer.namespace.baseName}.`,
+                    Diagnostic.Codes.WrongArgumentTypeError
+                    // TODO: Line information
+                )
+            );
+        }
+
+        if (!valueExpression.type.equals(elementType))
+        {
+            this.diagnostic.throw(
+                new Diagnostic.Error(
+                    `Array element type mismatch: expected ${elementType.namespace.baseName}.`,
+                    Diagnostic.Codes.WrongArgumentTypeError
+                    // TODO: Line information
+                )
+            );
+        }
+
+        return new SemanticNodes.ArraySetExpression(
+            elementType,
+            arrayExpression,
+            indexExpression,
+            valueExpression
+        );
     }
 
     private connectIdentifierExpression (
@@ -1367,8 +1529,8 @@ export class Connector
 
     private connectAccessExpression (
         expression: SyntaxNodes.AccessExpression,
-        context: ModuleContext
-    ): SemanticNodes.CallExpression|SemanticNodes.FieldExpression|SemanticNodes.VariableExpression
+        context: ModuleContext|FunctionContext
+    ): SemanticNodes.CallExpression|SemanticNodes.FieldExpression|SemanticNodes.VariableExpression|SemanticNodes.ArrayGetExpression|SemanticNodes.ArraySetExpression
     {
         const primaryExpression = this.connectExpression(expression.primaryExpression, context);
 
@@ -1473,9 +1635,14 @@ export class Connector
     private connectObjectAccessExpression (
         expression: SyntaxNodes.AccessExpression,
         primaryExpression: SemanticNodes.Expression,
-        context: ModuleContext
-    ): SemanticNodes.CallExpression|SemanticNodes.FieldExpression|SemanticNodes.VariableExpression
+        context: ModuleContext|FunctionContext
+    ): SemanticNodes.CallExpression|SemanticNodes.FieldExpression|SemanticNodes.VariableExpression|SemanticNodes.ArrayGetExpression|SemanticNodes.ArraySetExpression
     {
+        if (BuildInTypes.isArray(primaryExpression.type))
+        {
+            return this.connectArrayAccessExpression(expression, primaryExpression, context);
+        }
+
         const importedFile = this.importedFiles.get(primaryExpression.type.namespace.baseName);
         // TODO: Should we look for the class type by symbols instead of the module name here?
         if (importedFile === undefined)
@@ -1531,6 +1698,56 @@ export class Connector
                 }
             }
         }
+    }
+
+    private connectArrayAccessExpression (
+        expression: SyntaxNodes.AccessExpression,
+        arrayExpression: SemanticNodes.Expression,
+        context: ModuleContext|FunctionContext
+    ): SemanticNodes.ArrayGetExpression|SemanticNodes.ArraySetExpression|SemanticNodes.FieldExpression
+    {
+        /* TODO: This uses magic strings for the member names. We probably should not have them inline here. Could we put them somewhere
+                 logical together with "main", which is used as the name for the main function? */
+
+        if (expression.member.kind == SyntaxKind.CallExpression)
+        {
+            const elementType = BuildInTypes.getArrayElementType(arrayExpression.type);
+            if (elementType === null)
+            {
+                throw new Error('Connector error: Expected array type for array method call.');
+            }
+
+            const methodName = expression.member.identifier.content;
+
+            if (methodName === 'get')
+            {
+                return this.connectArrayGet(arrayExpression, expression.member.arguments, elementType, context);
+            }
+            else if (methodName === 'set')
+            {
+                return this.connectArraySet(arrayExpression, expression.member.arguments, elementType, context);
+            }
+        }
+        else
+        {
+            const fieldName = expression.member.identifier.content;
+
+            if (fieldName === 'length')
+            {
+                return new SemanticNodes.FieldExpression(
+                    BuildInTypes.arrayLengthField,
+                    arrayExpression
+                );
+            }
+        }
+
+        this.diagnostic.throw(
+            new Diagnostic.Error(
+                `Unknown identifier "${expression.member.identifier.content}" in array access.`,
+                Diagnostic.Codes.UnknownArrayAccessError,
+                expression.dot
+            )
+        );
     }
 
     private connectBracketedExpression (expression: SyntaxNodes.BracketedExpression, context: ModuleContext): SemanticNodes.Expression

--- a/src/connector/genericNodes/arrayGetExpressionGenericNode.ts
+++ b/src/connector/genericNodes/arrayGetExpressionGenericNode.ts
@@ -1,0 +1,21 @@
+import { SemanticKind } from '../semanticKind';
+
+export class ArrayGetExpressionGenericNode <Expression, TypeLike>
+{
+    public readonly kind: SemanticKind.ArrayGetExpression;
+
+    public readonly type: TypeLike;
+
+    public readonly array: Expression;
+    public readonly index: Expression;
+
+    constructor (type: TypeLike, array: Expression, index: Expression)
+    {
+        this.kind = SemanticKind.ArrayGetExpression;
+
+        this.type = type;
+
+        this.array = array;
+        this.index = index;
+    }
+}

--- a/src/connector/genericNodes/arrayInstantiationExpressionGenericNode.ts
+++ b/src/connector/genericNodes/arrayInstantiationExpressionGenericNode.ts
@@ -1,0 +1,21 @@
+import { SemanticKind } from '../semanticKind';
+
+export class ArrayInstantiationExpressionGenericNode <Expression, TypeLike>
+{
+    public readonly kind: SemanticKind.ArrayInstantiationExpression;
+
+    public readonly type: TypeLike;
+
+    public readonly elementType: TypeLike;
+    public readonly sizeArgument: Expression;
+
+    constructor (type: TypeLike, elementType: TypeLike, sizeArgument: Expression)
+    {
+        this.kind = SemanticKind.ArrayInstantiationExpression;
+
+        this.type = type;
+
+        this.elementType = elementType;
+        this.sizeArgument = sizeArgument;
+    }
+}

--- a/src/connector/genericNodes/arraySetExpressionGenericNode.ts
+++ b/src/connector/genericNodes/arraySetExpressionGenericNode.ts
@@ -1,0 +1,23 @@
+import { SemanticKind } from '../semanticKind';
+
+export class ArraySetExpressionGenericNode <Expression, TypeLike>
+{
+    public readonly kind: SemanticKind.ArraySetExpression;
+
+    public readonly type: TypeLike;
+
+    public readonly array: Expression;
+    public readonly index: Expression;
+    public readonly value: Expression;
+
+    constructor (type: TypeLike, array: Expression, index: Expression, value: Expression)
+    {
+        this.kind = SemanticKind.ArraySetExpression;
+
+        this.type = type;
+
+        this.array = array;
+        this.index = index;
+        this.value = value;
+    }
+}

--- a/src/connector/genericNodes/index.ts
+++ b/src/connector/genericNodes/index.ts
@@ -1,6 +1,9 @@
 /* TODO: "GenericNode" is too broad and collides with the concept of generic/specialised trees.
          Find a better way to describe its purpose regarding "SemanticNode"/"LoweredNode"/"SpecialisedNode". */
 
+export { ArrayGetExpressionGenericNode as ArrayGetExpression } from './arrayGetExpressionGenericNode';
+export { ArrayInstantiationExpressionGenericNode as ArrayInstantiationExpression } from './arrayInstantiationExpressionGenericNode';
+export { ArraySetExpressionGenericNode as ArraySetExpression } from './arraySetExpressionGenericNode';
 export { AssignmentGenericNode as Assignment } from './assignmentGenericNode';
 export { BinaryExpressionGenericNode as BinaryExpression } from './binaryExpressionGenericNode';
 export { CallExpressionGenericNode as CallExpression } from './callExpressionGenericNode';
@@ -21,6 +24,9 @@ export { UnaryExpressionGenericNode as UnaryExpression } from './unaryExpression
 export { VariableExpressionGenericNode as VariableExpression } from './variableExpressionGenericNode';
 export { WhileStatementGenericNode as WhileStatement } from './whileStatementGenericNode';
 
+import { ArrayGetExpressionGenericNode } from './arrayGetExpressionGenericNode';
+import { ArrayInstantiationExpressionGenericNode } from './arrayInstantiationExpressionGenericNode';
+import { ArraySetExpressionGenericNode } from './arraySetExpressionGenericNode';
 import { AssignmentGenericNode } from './assignmentGenericNode';
 import { BinaryExpressionGenericNode } from './binaryExpressionGenericNode';
 import { CallExpressionGenericNode } from './callExpressionGenericNode';
@@ -55,7 +61,10 @@ export type GenericNode<
     TypeLikeSymbol,
     ClassTypeSymbol
 > =
-    AssignmentGenericNode<Expression, FieldExpression, VariableExpression>
+    ArrayGetExpressionGenericNode<Expression, TypeLikeSymbol>
+    | ArrayInstantiationExpressionGenericNode<Expression, TypeLikeSymbol>
+    | ArraySetExpressionGenericNode<Expression, TypeLikeSymbol>
+    | AssignmentGenericNode<Expression, FieldExpression, VariableExpression>
     | BinaryExpressionGenericNode<Expression>
     | CallExpressionGenericNode<Expression, TypeLikeSymbol>
     | ElseClauseGenericNode<Section, IfStatement>
@@ -65,7 +74,6 @@ export type GenericNode<
     | FunctionDeclarationGenericNode<Section, TypeLikeSymbol>
     | GlobalVariableDeclarationGenericNode<Expression, TypeLikeSymbol>
     | IfStatementGenericNode<Expression, Section, ElseClause>
-    | InstantiationExpressionGenericNode<Expression, TypeLikeSymbol>
     | LiteralExpressionGenericNode<TypeLikeSymbol>
     | LocalVariableDeclarationGenericNode<Expression, TypeLikeSymbol>
     | ModuleExpressionGenericNode<ClassTypeSymbol, TypeLikeSymbol>
@@ -76,7 +84,8 @@ export type GenericNode<
     | WhileStatementGenericNode<Expression, Section>;
 
 export type GenericStatement<Expression, Statement, Section, ElseClause, VariableExpression, FieldExpression, TypeLikeSymbol> =
-    AssignmentGenericNode<Expression, FieldExpression, VariableExpression>
+    ArraySetExpressionGenericNode<Expression, TypeLikeSymbol>
+    | AssignmentGenericNode<Expression, FieldExpression, VariableExpression>
     | CallExpressionGenericNode<Expression, TypeLikeSymbol>
     | IfStatementGenericNode<Expression, Section, ElseClause>
     | LocalVariableDeclarationGenericNode<Expression, TypeLikeSymbol>
@@ -85,7 +94,9 @@ export type GenericStatement<Expression, Statement, Section, ElseClause, Variabl
     | WhileStatementGenericNode<Expression, Section>;
 
 export type GenericExpression<Expression, TypeLikeSymbol, ClassTypeSymbol> =
-    BinaryExpressionGenericNode<Expression>
+    ArrayGetExpressionGenericNode<Expression, TypeLikeSymbol>
+    | ArrayInstantiationExpressionGenericNode<Expression, TypeLikeSymbol>
+    | BinaryExpressionGenericNode<Expression>
     | CallExpressionGenericNode<Expression, TypeLikeSymbol>
     | FieldExpressionGenericNode<Expression, TypeLikeSymbol>
     | InstantiationExpressionGenericNode<Expression, TypeLikeSymbol>

--- a/src/connector/semanticKind.ts
+++ b/src/connector/semanticKind.ts
@@ -26,5 +26,10 @@ export enum SemanticKind
     UnaryExpression = 'UnaryExpression',
     BinaryExpression = 'BinaryExpression',
     SizeOfExpression = 'SizeOfExpression',
+    // Array-specific expressions
+    ArrayInstantiationExpression = 'ArrayInstantiationExpression',
+    ArrayGetExpression = 'ArrayGetExpression',
+    ArraySetExpression = 'ArraySetExpression',
+
     // TODO: Sort groups alphabetically.
 }

--- a/src/connector/semanticNodes/index.ts
+++ b/src/connector/semanticNodes/index.ts
@@ -1,6 +1,9 @@
 import * as GenericNodes from '../genericNodes';
 import * as SemanticSymbols from '../semanticSymbols';
 
+export class ArrayGetExpression extends GenericNodes.ArrayGetExpression<Expression, SemanticSymbols.TypeLike> {}
+export class ArrayInstantiationExpression extends GenericNodes.ArrayInstantiationExpression<Expression, SemanticSymbols.TypeLike> {}
+export class ArraySetExpression extends GenericNodes.ArraySetExpression<Expression, SemanticSymbols.TypeLike> {}
 export class Assignment extends GenericNodes.Assignment<Expression, FieldExpression, VariableExpression> {}
 export class BinaryExpression extends GenericNodes.BinaryExpression<Expression> {}
 export class CallExpression extends GenericNodes.CallExpression<Expression, SemanticSymbols.TypeLike> {}
@@ -49,7 +52,8 @@ export type SemanticNode =
     | WhileStatement;
 
 export type Statement =
-    Assignment
+    ArraySetExpression
+    | Assignment
     | CallExpression
     | IfStatement
     | LocalVariableDeclaration
@@ -58,7 +62,10 @@ export type Statement =
     | WhileStatement;
 
 export type Expression =
-    BinaryExpression
+    ArrayGetExpression
+    | ArrayInstantiationExpression
+    | ArraySetExpression // TODO: We should no have this here. It is needed because typing and usage mismatch, which is bad.
+    | BinaryExpression
     | CallExpression
     | FieldExpression
     | InstantiationExpression

--- a/src/definitions/buildInTypes.ts
+++ b/src/definitions/buildInTypes.ts
@@ -1,45 +1,142 @@
+import * as IntermediateSymbols from '../intermediateLowerer/intermediateSymbols';
 import * as SemanticSymbols from '../connector/semanticSymbols';
 import * as SpecialisedSymbols from '../specialiser/specialisedSymbols';
+import { IntermediateSize } from '../intermediateLowerer/intermediateSize';
 import { Namespace } from '../parser/namespace';
+import { SemanticSymbolKind } from '../connector/semanticSymbolKind';
 import { TokenKind } from '../lexer/tokenKind';
 
 export abstract class BuildInTypes
 {
-    public static readonly noType = new SpecialisedSymbols.ConcreteType(Namespace.constructFromStrings('Phosphor', 'NoType'), []);
-    // TODO: Integers are often misused for Cardinals. Should be corrected:
-    public static readonly integer = new SpecialisedSymbols.ConcreteType(Namespace.constructFromStrings('Phosphor', 'Integer'), []);
-    public static readonly boolean = new SpecialisedSymbols.ConcreteType(Namespace.constructFromStrings('Phosphor', 'Boolean'), []);
-    public static readonly string = new SpecialisedSymbols.ConcreteType(Namespace.constructFromStrings('Phosphor', 'String'), []);
-    public static readonly pointer = new SpecialisedSymbols.ConcreteType(Namespace.constructFromStrings('Phosphor', 'Pointer'), []);
+    private static readonly namespaceNoType = Namespace.constructFromStrings('Phosphor', 'NoType');
+    private static readonly namespaceInteger = Namespace.constructFromStrings('Phosphor', 'Integer');
+    private static readonly namespaceBoolean = Namespace.constructFromStrings('Phosphor', 'Boolean');
+    private static readonly namespaceString = Namespace.constructFromStrings('Phosphor', 'String');
+    private static readonly namespacePointer = Namespace.constructFromStrings('Phosphor', 'Pointer');
+    private static readonly namespaceArray = Namespace.constructFromStrings('Phosphor', 'Array');
 
-    public static getTypeByName (name: string): SemanticSymbols.GenericType|SemanticSymbols.ConcreteType|null
+    public static readonly noType = new SpecialisedSymbols.ConcreteType(BuildInTypes.namespaceNoType, []);
+    public static readonly integer = new SpecialisedSymbols.ConcreteType(BuildInTypes.namespaceInteger, []);
+    public static readonly boolean = new SpecialisedSymbols.ConcreteType(BuildInTypes.namespaceBoolean, []);
+    public static readonly string = new SpecialisedSymbols.ConcreteType(BuildInTypes.namespaceString, []);
+    public static readonly pointer = new SpecialisedSymbols.ConcreteType(BuildInTypes.namespacePointer, []);
+
+    public static readonly arrayLengthField = new SemanticSymbols.Field(
+        Namespace.constructFromNamespace(this.namespaceArray, 'length'),
+        BuildInTypes.integer,
+        true
+    );
+
+    /* TODO: There must be a better way than to special-case the arrays like that.
+             Could that be unified with the other types? Or at least be improved? */
+
+    public static isArray (type: { namespace: Namespace }): boolean
+    {
+        return type.namespace.baseName === BuildInTypes.namespaceArray.baseName;
+    }
+
+    public static isArrayStructure (structure: IntermediateSymbols.Structure): boolean
+    {
+        return structure.name === BuildInTypes.namespaceArray.baseName;
+    }
+
+    public static isBuildInType (type: { namespace: Namespace }): boolean
+    {
+        return type.namespace.equals(BuildInTypes.namespaceInteger)
+            || type.namespace.equals(BuildInTypes.namespaceBoolean)
+            || type.namespace.equals(BuildInTypes.namespaceString)
+            || type.namespace.equals(BuildInTypes.namespacePointer)
+            || type.namespace.equals(BuildInTypes.namespaceNoType)
+            || BuildInTypes.isArray(type);
+    }
+
+    public static createSemanticArrayType (elementType: SemanticSymbols.TypeLike): SemanticSymbols.ConcreteType
+    {
+        // TODO: It is a bit unfortunate to have this here; it should be part of the connector.
+
+        return new SemanticSymbols.ConcreteType(BuildInTypes.namespaceArray, [elementType]);
+    }
+
+    public static createSpecialisedArrayType (elementType: SpecialisedSymbols.ConcreteType): SpecialisedSymbols.ConcreteType
+    {
+        // TODO: It is a bit unfortunate to have this here; it should be part of the specialiser.
+
+        const specialisedNamespace = Namespace.constructFromNamespace(
+            BuildInTypes.namespaceArray,
+            [elementType.namespace]
+        );
+
+        return new SpecialisedSymbols.ConcreteType(specialisedNamespace, [elementType]);
+    }
+
+    public static createArrayIntermediateStructureSymbol (): IntermediateSymbols.Structure
+    {
+        // TODO: It is a bit unfortunate to have this here; where does it belong to? Should it exist at all?
+
+        const lengthField = new IntermediateSymbols.Field(this.arrayLengthField.namespace.baseName, IntermediateSize.Native, 0);
+
+        return new IntermediateSymbols.Structure(this.namespaceArray.baseName, [lengthField]);
+    }
+
+    public static getArrayElementType (type: SemanticSymbols.TypeLike): SemanticSymbols.TypeLike|null
+    {
+        if (type.namespace.baseName !== BuildInTypes.namespaceArray.baseName)
+        {
+            return null;
+        }
+
+        // Only concrete types have parameters:
+        if (type.kind !== SemanticSymbolKind.ConcreteType)
+        {
+            return null;
+        }
+
+        if (type.parameters.length !== 1)
+        {
+            return null;
+        }
+
+        return type.parameters[0];
+    }
+
+    public static getTypeByName (name: string): SpecialisedSymbols.ConcreteType|null
     {
         switch (name)
         {
-            case this.integer.namespace.baseName:
-                return this.integer;
-            case this.string.namespace.baseName:
-                return this.string;
-            case this.boolean.namespace.baseName:
-                return this.boolean;
-            case this.pointer.namespace.baseName:
-                return this.pointer;
+            case BuildInTypes.namespaceNoType.baseName:
+                return BuildInTypes.noType;
+            case BuildInTypes.namespaceInteger.baseName:
+                return BuildInTypes.integer;
+            case BuildInTypes.namespaceBoolean.baseName:
+                return BuildInTypes.boolean;
+            case BuildInTypes.namespaceString.baseName:
+                return BuildInTypes.string;
+            case BuildInTypes.namespacePointer.baseName:
+                return BuildInTypes.pointer;
+            case BuildInTypes.namespaceArray.baseName:
+                // Array is generic and cannot be returned without parameters:
+                return null;
             default:
                 return null;
         }
     }
 
-    public static getTypeByTokenKind (tokenKind: TokenKind): SemanticSymbols.GenericType|SemanticSymbols.ConcreteType|null
+    public static isArrayName (name: string): boolean
+    {
+        return name === BuildInTypes.namespaceArray.baseName;
+    }
+
+    public static getTypeByTokenKind (tokenKind: TokenKind): SpecialisedSymbols.ConcreteType|null
     {
         switch (tokenKind)
         {
             case TokenKind.IntegerToken:
-                return this.integer;
+                return BuildInTypes.integer;
             case TokenKind.StringToken:
-                return this.string;
+                return BuildInTypes.string;
             case TokenKind.TrueKeyword:
             case TokenKind.FalseKeyword:
-                return this.boolean;
+                return BuildInTypes.boolean;
             default:
                 return null;
         }

--- a/src/diagnostic/diagnosticCodes.ts
+++ b/src/diagnostic/diagnosticCodes.ts
@@ -75,6 +75,7 @@ export enum DiagnosticCodes // TODO: Should this be singular?
     UnknownIdentifierInObjectAccessError = 'E1076',
     UnexpectedTokenInGenericsDeclarationError = 'E1077',
     NonGenericTypeIsUsedAsGenericTypeError = 'E1078',
+    UnknownArrayAccessError = 'E1079',
     // Warnings:
     ExperimentalPlatformWarning = 'W1001',
     // Infos:

--- a/src/intermediateLowerer/intermediateKind.ts
+++ b/src/intermediateLowerer/intermediateKind.ts
@@ -9,6 +9,8 @@ export enum IntermediateKind
     // Statements:
     Add = 'Add',
     And = 'And',
+    ArrayLoad = 'ArrayLoad',
+    ArrayStore = 'ArrayStore',
     Call = 'Call',
     Compare = 'Compare',
     Divide = 'Divide',

--- a/src/intermediateLowerer/intermediateLowerer.ts
+++ b/src/intermediateLowerer/intermediateLowerer.ts
@@ -2,6 +2,7 @@ import * as Intermediates from './intermediates';
 import * as IntermediateSymbols from './intermediateSymbols';
 import * as LoweredNodes from '../semanticLowerer/loweredNodes';
 import * as SpecialisedSymbols from '../specialiser/specialisedSymbols';
+import { BuildInFunctions } from '../definitions/buildInFunctions';
 import { BuildInOperators } from '../definitions/buildInOperators';
 import { BuildInTypes } from '../definitions/buildInTypes';
 import { Intermediate } from './intermediates';
@@ -451,6 +452,9 @@ export class IntermediateLowerer
             case SemanticKind.ConditionalGotoStatement:
                 this.lowerConditionalGotoStatement(statement, intermediates);
                 break;
+            case SemanticKind.ArraySetExpression:
+                this.lowerArraySetExpression(statement, intermediates);
+                break;
         }
     }
 
@@ -605,6 +609,9 @@ export class IntermediateLowerer
             case SemanticKind.CallExpression:
                 this.lowerCallExpression(expression, intermediates, targetLocation);
                 break;
+            case SemanticKind.ArrayInstantiationExpression:
+                this.lowerArrayInstantiationExpression(expression, intermediates, targetLocation);
+                break;
             case SemanticKind.FieldExpression:
                 this.lowerFieldExpression(expression, intermediates, targetLocation);
                 break;
@@ -620,7 +627,132 @@ export class IntermediateLowerer
             case SemanticKind.VariableExpression:
                 this.lowerVariableExpression(expression, intermediates, targetLocation);
                 break;
+            case SemanticKind.ArrayGetExpression:
+                this.lowerArrayGetExpression(expression, intermediates, targetLocation);
+                break;
         }
+    }
+
+    private lowerArrayInstantiationExpression (
+        node: LoweredNodes.ArrayInstantiationExpression,
+        intermediates: Intermediate[],
+        targetLocation: IntermediateSymbols.WritableValue
+    ): void
+    {
+        /* TODO: It would be much preferable to have the array instantiation be lowered in the _semantic_ lowerer like every other
+                 instantiation/new expression. This could be possible by having a constructor on the array class that takes the size
+                 as a parameter and then allocates much like the ":classInitialiser" concept we have currently.
+                 Implementing that is non-trivial though and could be made easier by having most parts of the array be defined inside
+                 a Phosphor source file with special compiler handling of that file, which is not possible yet. */
+
+        // Array memory layout: { length: Integer, data: ElementType[] }
+
+        // Calculate the size.
+
+        const elementSize = this.typeToSize(node.elementType);
+
+        const elementByteSizeVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.introduceIfNecessary(elementByteSizeVariable, intermediates);
+        intermediates.push(
+            new Intermediates.SizeOf(elementByteSizeVariable, elementSize)
+        );
+
+        const sizeVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.lowerExpression(node.sizeArgument, intermediates, sizeVariable);
+
+        const dataSizeVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.introduceIfNecessary(dataSizeVariable, intermediates);
+        intermediates.push(
+            new Intermediates.Move(dataSizeVariable, sizeVariable)
+        );
+
+        intermediates.push(
+            new Intermediates.Multiply(dataSizeVariable, elementByteSizeVariable)
+        );
+
+        const headerSizeVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.introduceIfNecessary(headerSizeVariable, intermediates);
+        intermediates.push(
+            new Intermediates.SizeOf(headerSizeVariable, IntermediateSize.Native)
+        );
+
+        intermediates.push(
+            new Intermediates.Add(dataSizeVariable, headerSizeVariable)
+        );
+
+        // Call the allocate function.
+
+        const allocateFunctionSymbol = this.functionSymbolMap.get(BuildInFunctions.allocate.namespace.qualifiedName);
+        if (allocateFunctionSymbol === undefined)
+        {
+            throw new Error(
+                'Intermediate Lowerer error: Function "Standard.Memory~allocate" used before declaration.'
+            );
+        }
+
+        const parameter = this.generateParameter(IntermediateSize.Native, 0);
+        intermediates.push(
+            new Intermediates.Give(parameter, dataSizeVariable)
+        );
+
+        intermediates.push(
+            new Intermediates.Call(allocateFunctionSymbol)
+        );
+
+        this.introduceIfNecessary(targetLocation, intermediates);
+
+        const returnValue = new IntermediateSymbols.ReturnValue(0, IntermediateSize.Pointer);
+        intermediates.push(
+            new Intermediates.Take(targetLocation, returnValue)
+        );
+
+        // Store the length in the array object.
+
+        const arrayStructureSymbol = BuildInTypes.createArrayIntermediateStructureSymbol();
+        const lengthFieldSymbol = arrayStructureSymbol.fields[0]; // The length field is at index 0.
+
+        intermediates.push(
+            new Intermediates.StoreField(sizeVariable, arrayStructureSymbol, targetLocation, lengthFieldSymbol)
+        );
+    }
+
+    private lowerArrayGetExpression (
+        node: LoweredNodes.ArrayGetExpression,
+        intermediates: Intermediate[],
+        targetLocation: IntermediateSymbols.WritableValue
+    ): void
+    {
+        const arrayVariable = this.generateLocalVariable(IntermediateSize.Pointer);
+        this.lowerExpression(node.array, intermediates, arrayVariable);
+
+        const indexVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.lowerExpression(node.index, intermediates, indexVariable);
+
+        const elementSize = this.typeToSize(node.type);
+
+        this.introduceIfNecessary(targetLocation, intermediates);
+
+        intermediates.push(
+            new Intermediates.ArrayLoad(targetLocation, arrayVariable, indexVariable, elementSize)
+        );
+    }
+
+    private lowerArraySetExpression (node: LoweredNodes.ArraySetExpression, intermediates: Intermediate[]): void
+    {
+        const arrayVariable = this.generateLocalVariable(IntermediateSize.Pointer);
+        this.lowerExpression(node.array, intermediates, arrayVariable);
+
+        const indexVariable = this.generateLocalVariable(IntermediateSize.Native);
+        this.lowerExpression(node.index, intermediates, indexVariable);
+
+        const elementSize = this.typeToSize(node.type);
+
+        const valueVariable = this.generateLocalVariable(elementSize);
+        this.lowerExpression(node.value, intermediates, valueVariable);
+
+        intermediates.push(
+            new Intermediates.ArrayStore(arrayVariable, indexVariable, valueVariable, elementSize)
+        );
     }
 
     private lowerSizeOfExpression (
@@ -634,15 +766,16 @@ export class IntermediateLowerer
             throw new Error('Intermediate Lowerer error: Current module is null while lowering a sizeOf expression.');
         }
 
+        this.introduceIfNecessary(targetLocation, intermediates);
+
         if (sizeOfExpression.parameter.namespace.qualifiedName !== this.currentModule.namespace.qualifiedName)
         {
             throw new Error('Intermediate Lowerer error: The sizeOf expression is not implemented for parameters from other modules.');
         }
 
-        this.introduceIfNecessary(targetLocation, intermediates);
-
         if (this.structure === null)
         {
+            // TODO: If not a structure, it's a module, so the size of a module is zero? When could that be needed?
             intermediates.push(
                 new Intermediates.Move(
                     targetLocation,
@@ -741,6 +874,41 @@ export class IntermediateLowerer
     private lowerFieldExpression (
         fieldExpression: LoweredNodes.FieldExpression,
         intermediates: Intermediate[],
+        targetLocation: IntermediateSymbols.WritableValue
+    ): void
+    {
+        if (fieldExpression.field.equals(BuildInTypes.arrayLengthField))
+        {
+            this.lowerArrayFieldExpression(fieldExpression, intermediates, targetLocation);
+        }
+        else
+        {
+            this.lowerObjectFieldExpression(fieldExpression, intermediates, targetLocation);
+        }
+    }
+
+    private lowerArrayFieldExpression (
+        fieldExpression: LoweredNodes.FieldExpression,
+        intermediates: Intermediates.Intermediate[],
+        targetLocation: IntermediateSymbols.WritableValue
+    ): void
+    {
+        const thisReference = this.generateLocalVariable(IntermediateSize.Pointer);
+        this.lowerExpression(fieldExpression.thisReference, intermediates, thisReference);
+
+        this.introduceIfNecessary(targetLocation, intermediates);
+
+        const arrayStructureSymbol = BuildInTypes.createArrayIntermediateStructureSymbol();
+        const lengthField = arrayStructureSymbol.fields[0]; // The length field is at index 0.
+
+        intermediates.push(
+            new Intermediates.LoadField(targetLocation, arrayStructureSymbol, thisReference, lengthField)
+        );
+    }
+
+    private lowerObjectFieldExpression (
+        fieldExpression: LoweredNodes.FieldExpression,
+        intermediates: Intermediates.Intermediate[],
         targetLocation: IntermediateSymbols.WritableValue
     ): void
     {

--- a/src/intermediateLowerer/intermediates/arrayLoadIntermediate.ts
+++ b/src/intermediateLowerer/intermediates/arrayLoadIntermediate.ts
@@ -1,0 +1,30 @@
+import * as IntermediateSymbols from '../intermediateSymbols';
+import { IntermediateKind } from '../intermediateKind';
+import { IntermediateSize } from '../intermediateSize';
+
+/**
+ * Load an element from an array at a given index.
+ */
+export class ArrayLoadIntermediate
+{
+    public readonly kind: IntermediateKind.ArrayLoad;
+
+    public readonly to: IntermediateSymbols.WritableValue;
+    public readonly array: IntermediateSymbols.ReadableValue;
+    public readonly index: IntermediateSymbols.ReadableValue;
+    public readonly size: IntermediateSize;
+
+    constructor (
+        to: IntermediateSymbols.WritableValue,
+        array: IntermediateSymbols.ReadableValue,
+        index: IntermediateSymbols.ReadableValue,
+        size: IntermediateSize
+    ) {
+        this.kind = IntermediateKind.ArrayLoad;
+
+        this.to = to;
+        this.array = array;
+        this.index = index;
+        this.size = size;
+    }
+}

--- a/src/intermediateLowerer/intermediates/arrayStoreIntermediate.ts
+++ b/src/intermediateLowerer/intermediates/arrayStoreIntermediate.ts
@@ -1,0 +1,30 @@
+import * as IntermediateSymbols from '../intermediateSymbols';
+import { IntermediateKind } from '../intermediateKind';
+import { IntermediateSize } from '../intermediateSize';
+
+/**
+ * Store a value into an array at a given index.
+ */
+export class ArrayStoreIntermediate
+{
+    public readonly kind: IntermediateKind.ArrayStore;
+
+    public readonly array: IntermediateSymbols.ReadableValue;
+    public readonly index: IntermediateSymbols.ReadableValue;
+    public readonly source: IntermediateSymbols.ReadableValue;
+    public readonly size: IntermediateSize;
+
+    constructor (
+        array: IntermediateSymbols.ReadableValue,
+        index: IntermediateSymbols.ReadableValue,
+        source: IntermediateSymbols.ReadableValue,
+        size: IntermediateSize
+    ) {
+        this.kind = IntermediateKind.ArrayStore;
+
+        this.array = array;
+        this.index = index;
+        this.source = source;
+        this.size = size;
+    }
+}

--- a/src/intermediateLowerer/intermediates/index.ts
+++ b/src/intermediateLowerer/intermediates/index.ts
@@ -1,5 +1,7 @@
 export { AddIntermediate as Add } from './addIntermediate';
 export { AndIntermediate as And } from './andIntermediate';
+export { ArrayLoadIntermediate as ArrayLoad } from './arrayLoadIntermediate';
+export { ArrayStoreIntermediate as ArrayStore } from './arrayStoreIntermediate';
 export { CallIntermediate as Call } from './callIntermediate';
 export { CompareIntermediate as Compare } from './compareIntermediate';
 export { ConstantIntermediate as Constant } from './constantIntermediate';
@@ -32,6 +34,8 @@ export { TakeIntermediate as Take } from './takeIntermediate';
 
 import { AddIntermediate } from './addIntermediate';
 import { AndIntermediate } from './andIntermediate';
+import { ArrayLoadIntermediate } from './arrayLoadIntermediate';
+import { ArrayStoreIntermediate } from './arrayStoreIntermediate';
 import { CallIntermediate } from './callIntermediate';
 import { CompareIntermediate } from './compareIntermediate';
 import { ConstantIntermediate } from './constantIntermediate';
@@ -66,6 +70,8 @@ export type Intermediate =
     LoadFieldIntermediate
     | AddIntermediate
     | AndIntermediate
+    | ArrayLoadIntermediate
+    | ArrayStoreIntermediate
     | CallIntermediate
     | CompareIntermediate
     | ConstantIntermediate
@@ -98,6 +104,8 @@ export type Intermediate =
 export type Statement =
     AddIntermediate
     | AndIntermediate
+    | ArrayLoadIntermediate
+    | ArrayStoreIntermediate
     | CallIntermediate
     | CompareIntermediate
     | DivideIntermediate

--- a/src/intermediateLowerer/intermediates/sizeOfIntermediate.ts
+++ b/src/intermediateLowerer/intermediates/sizeOfIntermediate.ts
@@ -1,5 +1,6 @@
 import * as IntermediateSymbols from '../intermediateSymbols';
 import { IntermediateKind } from '../intermediateKind';
+import { IntermediateSize } from '../intermediateSize';
 
 /**
  * The size of the given structure, to be determined by the transpiler.
@@ -9,13 +10,13 @@ export class SizeOfIntermediate
     public readonly kind: IntermediateKind.SizeOf;
 
     public readonly to: IntermediateSymbols.WritableValue;
-    public readonly structure: IntermediateSymbols.Structure;
+    public readonly of: IntermediateSymbols.Structure|IntermediateSize;
 
-    constructor (to: IntermediateSymbols.WritableValue, structure: IntermediateSymbols.Structure)
+    constructor (to: IntermediateSymbols.WritableValue, of: IntermediateSymbols.Structure|IntermediateSize)
     {
         this.kind = IntermediateKind.SizeOf;
 
         this.to = to;
-        this.structure = structure;
+        this.of = of;
     }
 }

--- a/src/semanticLowerer/loweredNodes/index.ts
+++ b/src/semanticLowerer/loweredNodes/index.ts
@@ -1,6 +1,9 @@
 import * as GenericNode from '../../connector/genericNodes';
 import * as SpecialisedSymbols from '../../specialiser/specialisedSymbols';
 
+export class ArrayGetExpression extends GenericNode.ArrayGetExpression<Expression, SpecialisedSymbols.ConcreteType> {}
+export class ArrayInstantiationExpression extends GenericNode.ArrayInstantiationExpression<Expression, SpecialisedSymbols.ConcreteType> {}
+export class ArraySetExpression extends GenericNode.ArraySetExpression<Expression, SpecialisedSymbols.ConcreteType> {}
 export class Assignment extends GenericNode.Assignment<Expression, FieldExpression, VariableExpression> {}
 export class BinaryExpression extends GenericNode.BinaryExpression<Expression> {}
 export class CallExpression extends GenericNode.CallExpression<Expression, SpecialisedSymbols.ConcreteType> {}
@@ -31,7 +34,10 @@ import { LabelLoweredNode } from './labelLoweredNode';
 import { SizeOfExpressionLoweredNode } from './sizeOfExpressionLoweredNode';
 
 export type LoweredNode =
-    Assignment
+    ArrayGetExpression
+    | ArrayInstantiationExpression
+    | ArraySetExpression
+    | Assignment
     | BinaryExpression
     | CallExpression
     | File
@@ -49,7 +55,8 @@ export type LoweredNode =
     | SizeOfExpressionLoweredNode;
 
 export type Statement =
-    Assignment
+    ArraySetExpression
+    | Assignment
     | CallExpression
     | LocalVariableDeclaration
     | ReturnStatement
@@ -59,7 +66,9 @@ export type Statement =
     | LabelLoweredNode;
 
 export type Expression =
-    BinaryExpression
+    ArrayGetExpression
+    | ArrayInstantiationExpression
+    | BinaryExpression
     | CallExpression
     | FieldExpression
     | LiteralExpression

--- a/src/semanticLowerer/semanticLowerer.ts
+++ b/src/semanticLowerer/semanticLowerer.ts
@@ -380,6 +380,8 @@ export default class SemanticLowerer
                 return [this.lowerAssignment(statement)];
             case SemanticKind.CallExpression:
                 return [this.lowerCallExpression(statement)];
+            case SemanticKind.ArraySetExpression:
+                return [this.lowerArraySetExpression(statement)];
             case SemanticKind.IfStatement:
                 return this.lowerIfStatement(statement);
             case SemanticKind.LocalVariableDeclaration:
@@ -554,6 +556,12 @@ export default class SemanticLowerer
                 return this.lowerFieldExpression(expression);
             case SemanticKind.InstantiationExpression:
                 return this.lowerInstantiationExpression(expression);
+            case SemanticKind.ArrayInstantiationExpression:
+                return this.lowerArrayInstantiation(expression);
+            case SemanticKind.ArrayGetExpression:
+                return this.lowerArrayGetExpression(expression);
+            case SemanticKind.ArraySetExpression:
+                throw new Error(`Semantic Lowerer error: Array set is used as an expression instead of a statement.`);
             case SemanticKind.LiteralExpression:
                 return this.lowerLiteralExpression(expression);
             case SemanticKind.ModuleExpression:
@@ -563,6 +571,41 @@ export default class SemanticLowerer
             case SemanticKind.VariableExpression:
                 return this.lowerVariableExpression(expression);
         }
+    }
+
+    private lowerArrayInstantiation (arrayInstantiation: SpecialisedNodes.ArrayInstantiationExpression):
+        LoweredNodes.ArrayInstantiationExpression
+    {
+        // Pass the array instantiation to the intermediate lowerer
+        // where it will be properly handled (allocation + storing the length in the header)
+
+        // We need to import the Memory module for the allocate function
+        this.importBuildInModuleIfNeeded(BuildInModules.memory);
+
+        const loweredSize = this.lowerExpression(arrayInstantiation.sizeArgument);
+
+        return new LoweredNodes.ArrayInstantiationExpression(
+            arrayInstantiation.type,
+            arrayInstantiation.elementType,
+            loweredSize
+        );
+    }
+
+    private lowerArrayGetExpression (arrayGetExpression: SpecialisedNodes.ArrayGetExpression): LoweredNodes.ArrayGetExpression
+    {
+        const loweredArray = this.lowerExpression(arrayGetExpression.array);
+        const loweredIndex = this.lowerExpression(arrayGetExpression.index);
+
+        return new LoweredNodes.ArrayGetExpression(arrayGetExpression.type, loweredArray, loweredIndex);
+    }
+
+    private lowerArraySetExpression (arraySetExpression: SpecialisedNodes.ArraySetExpression): LoweredNodes.ArraySetExpression
+    {
+        const loweredArray = this.lowerExpression(arraySetExpression.array);
+        const loweredIndex = this.lowerExpression(arraySetExpression.index);
+        const loweredValue = this.lowerExpression(arraySetExpression.value);
+
+        return new LoweredNodes.ArraySetExpression(arraySetExpression.type, loweredArray, loweredIndex, loweredValue);
     }
 
     private lowerCallExpression (callExpression: SpecialisedNodes.CallExpression): LoweredNodes.CallExpression

--- a/src/specialiser/specialisedNodes/index.ts
+++ b/src/specialiser/specialisedNodes/index.ts
@@ -1,6 +1,9 @@
 import * as GenericNodes from '../../connector/genericNodes';
 import * as SpecialisedSymbols from '../specialisedSymbols';
 
+export class ArrayGetExpression extends GenericNodes.ArrayGetExpression<Expression, SpecialisedSymbols.ConcreteType> {}
+export class ArrayInstantiationExpression extends GenericNodes.ArrayInstantiationExpression<Expression, SpecialisedSymbols.ConcreteType> {}
+export class ArraySetExpression extends GenericNodes.ArraySetExpression<Expression, SpecialisedSymbols.ConcreteType> {}
 export class Assignment extends GenericNodes.Assignment<Expression, FieldExpression, VariableExpression> {}
 export class BinaryExpression extends GenericNodes.BinaryExpression<Expression> {}
 export class CallExpression extends GenericNodes.CallExpression<Expression, SpecialisedSymbols.ConcreteType> {}
@@ -28,7 +31,10 @@ export class VariableExpression extends GenericNodes.VariableExpression<Speciali
 export class WhileStatement extends GenericNodes.WhileStatement<Expression, Section> {}
 
 export type SpecialisedNode = // TODO: Rename to "Node"?
-    Assignment
+    ArrayGetExpression
+    | ArrayInstantiationExpression
+    | ArraySetExpression
+    | Assignment
     | BinaryExpression
     | CallExpression
     | ElseClause
@@ -49,7 +55,8 @@ export type SpecialisedNode = // TODO: Rename to "Node"?
     | WhileStatement;
 
 export type Statement =
-    Assignment
+    ArraySetExpression
+    | Assignment
     | CallExpression
     | IfStatement
     | LocalVariableDeclaration
@@ -58,7 +65,10 @@ export type Statement =
     | WhileStatement;
 
 export type Expression =
-    BinaryExpression
+    ArrayGetExpression
+    | ArrayInstantiationExpression
+    | ArraySetExpression
+    | BinaryExpression
     | CallExpression
     | FieldExpression
     | InstantiationExpression

--- a/src/specialiser/specialiser.ts
+++ b/src/specialiser/specialiser.ts
@@ -2,6 +2,7 @@ import * as SemanticNodes from '../connector/semanticNodes';
 import * as SemanticSymbols from '../connector/semanticSymbols';
 import * as SpecialisedNodes from './specialisedNodes';
 import * as SpecialisedSymbols from './specialisedSymbols';
+import { BuildInTypes } from '../definitions/buildInTypes';
 import { Namespace } from '../parser/namespace';
 import { SemanticKind } from '../connector/semanticKind';
 import { SemanticSymbolKind } from '../connector/semanticSymbolKind';
@@ -388,9 +389,14 @@ export class Specialiser
         {
             if (type.parameters.length === 0)
             {
-                /* HACK: We have this bad casting here because we need the identity for checks with build-in functions
-                         in the lowerers. Solving this requires a more fundamental change in handling the build-in functions. */
-                return type as SpecialisedSymbols.ConcreteType;
+
+                const builtIn = BuildInTypes.getTypeByName(type.namespace.baseName);
+                if (builtIn !== null)
+                {
+                    return builtIn;
+                }
+
+                return new SpecialisedSymbols.ConcreteType(type.namespace, []);
             }
 
             const specialisedParameters: SpecialisedSymbols.ConcreteType[] = [];
@@ -402,6 +408,11 @@ export class Specialiser
                     throw new Error(`Specialiser error: Type parameter in "${type.namespace.qualifiedName}" is null.`);
                 }
                 specialisedParameters.push(specialisedParameter);
+            }
+
+            if (BuildInTypes.isArray(type))
+            {
+                return BuildInTypes.createSpecialisedArrayType(specialisedParameters[0]);
             }
 
             const parameterNamespaces = this.getNamespacesFromTypes(specialisedParameters);
@@ -766,16 +777,16 @@ export class Specialiser
                 return this.specialiseReturnStatement(statement);
             case SemanticKind.Section:
                 return this.specialiseSection(statement);
+            case SemanticKind.ArraySetExpression:
+                return this.specialiseArraySetExpression(statement);
             case SemanticKind.WhileStatement:
                 return this.specialiseWhileStatement(statement);
-            default:
-                throw new Error(`Specialiser error: Unknown statement kind "${(statement as SemanticNodes.Statement).kind}".`);
         }
     }
 
     private specialiseAssignment (assignment: SemanticNodes.Assignment): SpecialisedNodes.Assignment
     {
-        let specialisedTo: SpecialisedNodes.Expression;
+        let specialisedTo: SpecialisedNodes.FieldExpression|SpecialisedNodes.VariableExpression;
         if (assignment.to.kind === SemanticKind.FieldExpression)
         {
             specialisedTo = this.specialiseFieldExpression(assignment.to);
@@ -863,6 +874,12 @@ export class Specialiser
     {
         switch (expression.kind)
         {
+            case SemanticKind.ArrayGetExpression:
+                return this.specialiseArrayGetExpression(expression);
+            case SemanticKind.ArrayInstantiationExpression:
+                return this.specialiseArrayInstantiation(expression);
+            case SemanticKind.ArraySetExpression:
+                return this.specialiseArraySetExpression(expression);
             case SemanticKind.BinaryExpression:
                 return this.specialiseBinaryExpression(expression);
             case SemanticKind.CallExpression:
@@ -879,8 +896,6 @@ export class Specialiser
                 return this.specialiseUnaryExpression(expression);
             case SemanticKind.VariableExpression:
                 return this.specialiseVariableExpression(expression);
-            default:
-                throw new Error(`Specialiser error: Unknown expression kind "${(expression as SemanticNodes.Expression).kind}".`);
         }
     }
 
@@ -890,6 +905,62 @@ export class Specialiser
         const specialisedRight = this.specialiseExpression(expression.rightOperand);
 
         return new SpecialisedNodes.BinaryExpression(expression.operator, specialisedLeft, specialisedRight);
+    }
+
+    private specialiseArrayInstantiation (node: SemanticNodes.ArrayInstantiationExpression): SpecialisedNodes.ArrayInstantiationExpression
+    {
+        const specialisedType = this.specialiseType(node.type);
+        const specialisedElementType = this.specialiseType(node.elementType);
+        const specialisedSizeArgument = this.specialiseExpression(node.sizeArgument);
+
+        if ((specialisedType === null) || (specialisedElementType === null))
+        {
+            throw new Error(`Specialiser error: Array instantiation has a null type.`);
+        }
+
+        return new SpecialisedNodes.ArrayInstantiationExpression(
+            specialisedType,
+            specialisedElementType,
+            specialisedSizeArgument
+        );
+    }
+
+    private specialiseArrayGetExpression (node: SemanticNodes.ArrayGetExpression): SpecialisedNodes.ArrayGetExpression
+    {
+        const specialisedType = this.specialiseType(node.type);
+        const specialisedArrayExpression = this.specialiseExpression(node.array);
+        const specialisedIndexExpression = this.specialiseExpression(node.index);
+
+        if (specialisedType === null)
+        {
+            throw new Error(`Specialiser error: Array get expression has a null type.`);
+        }
+
+        return new SpecialisedNodes.ArrayGetExpression(
+            specialisedType,
+            specialisedArrayExpression,
+            specialisedIndexExpression
+        );
+    }
+
+    private specialiseArraySetExpression (node: SemanticNodes.ArraySetExpression): SpecialisedNodes.ArraySetExpression
+    {
+        const specialisedElementType = this.specialiseType(node.type);
+        const specialisedArrayExpression = this.specialiseExpression(node.array);
+        const specialisedIndexExpression = this.specialiseExpression(node.index);
+        const specialisedValueExpression = this.specialiseExpression(node.value);
+
+        if (specialisedElementType === null)
+        {
+            throw new Error(`Specialiser error: Array set expression has a null element type.`);
+        }
+
+        return new SpecialisedNodes.ArraySetExpression(
+            specialisedElementType,
+            specialisedArrayExpression,
+            specialisedIndexExpression,
+            specialisedValueExpression
+        );
     }
 
     private specialiseCallExpression (expression: SemanticNodes.CallExpression): SpecialisedNodes.CallExpression

--- a/src/transpiler/intermediate/transpilerIntermediate.ts
+++ b/src/transpiler/intermediate/transpilerIntermediate.ts
@@ -1,5 +1,6 @@
 import * as Instructions from '../common/instructions';
 import * as Intermediates from '../../intermediateLowerer/intermediates';
+import * as IntermediateSymbols from '../../intermediateLowerer/intermediateSymbols';
 import { IntermediateKind } from '../../intermediateLowerer/intermediateKind';
 import { IntermediateSymbol } from '../../intermediateLowerer/intermediateSymbols';
 import { IntermediateSymbolKind } from '../../intermediateLowerer/intermediateSymbolKind';
@@ -72,6 +73,10 @@ export class TranspilerIntermediate
                 return 'loadField';
             case IntermediateKind.StoreField:
                 return 'storeField';
+            case IntermediateKind.ArrayLoad:
+                return 'arrayLoad';
+            case IntermediateKind.ArrayStore:
+                return 'arrayStore';
             case IntermediateKind.Add:
                 return 'add';
             case IntermediateKind.And:
@@ -338,6 +343,22 @@ export class TranspilerIntermediate
                     this.getIntermediateSymbolString(statementIntermediate.field),
                 ];
                 break;
+            case IntermediateKind.ArrayLoad:
+                parameters = [
+                    this.getIntermediateSymbolString(statementIntermediate.to),
+                    this.getIntermediateSymbolString(statementIntermediate.array),
+                    this.getIntermediateSymbolString(statementIntermediate.index),
+                    statementIntermediate.size,
+                ];
+                break;
+            case IntermediateKind.ArrayStore:
+                parameters = [
+                    this.getIntermediateSymbolString(statementIntermediate.array),
+                    this.getIntermediateSymbolString(statementIntermediate.index),
+                    this.getIntermediateSymbolString(statementIntermediate.source),
+                    statementIntermediate.size,
+                ];
+                break;
             case IntermediateKind.Negate:
             case IntermediateKind.Not:
                 parameters = [
@@ -360,10 +381,7 @@ export class TranspilerIntermediate
                 parameters = [];
                 break;
             case IntermediateKind.SizeOf:
-                parameters = [
-                    this.getIntermediateSymbolString(statementIntermediate.to),
-                    this.getIntermediateSymbolString(statementIntermediate.structure),
-                ];
+                parameters = this.getParametersForSizeOfInstruction(statementIntermediate);
                 break;
             case IntermediateKind.Label:
                 this.instructions.push(
@@ -380,5 +398,23 @@ export class TranspilerIntermediate
                 ...parameters,
             ),
         );
+    }
+
+    private getParametersForSizeOfInstruction (sizeOfIntermediate: Intermediates.SizeOf): string[]
+    {
+        const parameters: string[] = [
+            this.getIntermediateSymbolString(sizeOfIntermediate.to),
+        ];
+
+        if (sizeOfIntermediate.of instanceof IntermediateSymbols.Structure)
+        {
+            parameters.push(this.getIntermediateSymbolString(sizeOfIntermediate.of));
+        }
+        else
+        {
+            parameters.push(sizeOfIntermediate.of);
+        }
+
+        return parameters;
     }
 }

--- a/src/transpiler/llvm/transpilerLlvm.ts
+++ b/src/transpiler/llvm/transpilerLlvm.ts
@@ -3,6 +3,7 @@ import * as Intermediates from '../../intermediateLowerer/intermediates';
 import * as IntermediateSymbols from '../../intermediateLowerer/intermediateSymbols';
 import * as LlvmInstructions from './llvmInstructions';
 import { ArrayBuilder } from '../../utility/arrayBuilder';
+import { BuildInTypes } from '../../definitions/buildInTypes';
 import { IntermediateKind } from '../../intermediateLowerer/intermediateKind';
 import { IntermediateSize } from '../../intermediateLowerer/intermediateSize';
 import { IntermediateSymbolKind } from '../../intermediateLowerer/intermediateSymbolKind';
@@ -192,6 +193,26 @@ export class TranspilerLlvm
         }
     }
 
+    private getByteCountForIntermediateSize (intermediateSize: IntermediateSize): number
+    {
+        switch (intermediateSize)
+        {
+            case IntermediateSize.Int8:
+                return 1;
+            case IntermediateSize.Int16:
+                return 2;
+            case IntermediateSize.Int32:
+                return 4;
+            case IntermediateSize.Int64:
+                return 8;
+            case IntermediateSize.Native:
+            case IntermediateSize.Pointer:
+                return 8; // FIXME: Input actual target word size.
+            case IntermediateSize.Void:
+                return 0;
+        }
+    }
+
     /**
      * Load a variable into a register.
      * @param variable The variable to load from.
@@ -215,6 +236,48 @@ export class TranspilerLlvm
         );
 
         return registerName;
+    }
+
+    /**
+     * Load a readable value into a register.
+     * @param value The readable value to load from.
+     * @returns The name of the register or the literal value.
+     */
+    private loadReadableValueIntoRegister (value: IntermediateSymbols.ReadableValue): string
+    {
+        switch (value.kind)
+        {
+            case IntermediateSymbolKind.Constant:
+            {
+                const constantName = this.getLlvmGlobalName(value);
+                const constantSizeString = this.getLlvmSizeString(value.size);
+                const byteSizeString = this.getLlvmSizeString(IntermediateSize.Int8);
+                const registerName = this.nextVariableName;
+
+                const pointerString = `getelementptr (${byteSizeString}, ${constantSizeString} ${constantName}, ${byteSizeString} 0)`;
+
+                this.instructions.push(
+                    new LlvmInstructions.Assignment(
+                        registerName,
+                        'load',
+                        this.pointerSizeString + ',',
+                        this.pointerSizeString,
+                        pointerString,
+                    ),
+                );
+
+                return registerName;
+            }
+            case IntermediateSymbolKind.LocalVariable:
+            case IntermediateSymbolKind.GlobalVariable:
+            {
+                return this.loadIntoRegister(value);
+            }
+            case IntermediateSymbolKind.Literal:
+            {
+                return value.value;
+            }
+        }
     }
 
     /**
@@ -242,7 +305,17 @@ export class TranspilerLlvm
         fieldIndex: number
     ): string
     {
-        const baseType = this.getLlvmLocalName(structure);
+        let baseType: string;
+        if (BuildInTypes.isArrayStructure(structure))
+        {
+            // Hack: It's a bit hacky having this here. And a bit more hacky to omit the data after the length field.
+            baseType = `{${this.getLlvmSizeString(structure.fields[0].size)}}`;
+        }
+        else
+        {
+            baseType = this.getLlvmLocalName(structure);
+        }
+
         const pointerType = this.getLlvmSizeString(IntermediateSize.Pointer);
         const basePointer = this.loadIntoRegister(thisReference);
         const byteSize = this.getLlvmSizeString(IntermediateSize.Int32);
@@ -536,6 +609,12 @@ export class TranspilerLlvm
             case IntermediateKind.StoreField:
                 this.transpileStoreField(statementIntermediate);
                 break;
+            case IntermediateKind.ArrayLoad:
+                this.transpileArrayLoad(statementIntermediate);
+                break;
+            case IntermediateKind.ArrayStore:
+                this.transpileArrayStore(statementIntermediate);
+                break;
             case IntermediateKind.Subtract:
                 this.transpileSubtract(statementIntermediate);
                 break;
@@ -547,13 +626,25 @@ export class TranspilerLlvm
 
     private transpileSizeOf (sizeOfIntermediate: Intermediates.SizeOf): void
     {
-        // NOTE: The SizeOfExpression in LLVM is a trick.
+        if (sizeOfIntermediate.of instanceof IntermediateSymbols.Structure)
+        {
+            this.transpileSizeOfStructure(sizeOfIntermediate.of, sizeOfIntermediate.to);
+        }
+        else
+        {
+            this.transpileSizeOfSize(sizeOfIntermediate.of, sizeOfIntermediate.to);
+        }
+    }
+
+    private transpileSizeOfStructure (structure: IntermediateSymbols.Structure, target: IntermediateSymbols.WritableValue): void
+    {
+        // NOTE: For structures, the SizeOfExpression in LLVM is a trick.
         // By utilising the getelementptr instruction, we can get the size of a type:
         // %sizePointer = getelementptr (%MyType, ptr null, i8 1)
         // %size = ptrtoint ptr %sizePointer to ToSize
         // It is quaranteed to be optimised away into a constant by the LLVM compiler.
 
-        const structureTypeString = this.getLlvmLocalName(sizeOfIntermediate.structure);
+        const structureTypeString = this.getLlvmLocalName(structure);
         const pointerType = this.getLlvmSizeString(IntermediateSize.Pointer);
         const byteSizeString = this.getLlvmSizeString(IntermediateSize.Int8);
 
@@ -570,11 +661,88 @@ export class TranspilerLlvm
                 pointerType,
                 sizePointerRegister,
                 'to',
-                this.getLlvmSizeString(sizeOfIntermediate.to.size),
+                this.getLlvmSizeString(target.size),
             ),
         );
 
-        this.storeIntoVariable(sizeRegister, sizeOfIntermediate.to);
+        this.storeIntoVariable(sizeRegister, target);
+    }
+
+    private transpileSizeOfSize (size: IntermediateSize, target: IntermediateSymbols.WritableValue): void
+    {
+        const byteCount = this.getByteCountForIntermediateSize(size);
+        this.storeIntoVariable(byteCount.toString(), target);
+    }
+
+    private transpileArrayLoad (loadIntermediate: Intermediates.ArrayLoad): void
+    {
+        const elementPointerRegister =this.loadArrayIndexIntoVariable(
+            loadIntermediate.array,
+            loadIntermediate.index,
+            loadIntermediate.size,
+        );
+
+        const elementRegister = this.nextVariableName;
+
+        this.instructions.push(
+            new LlvmInstructions.Assignment(
+                elementRegister,
+                'load',
+                this.getLlvmSizeString(loadIntermediate.size) + ',',
+                this.pointerSizeString,
+                elementPointerRegister,
+            ),
+        );
+
+        this.storeIntoVariable(elementRegister, loadIntermediate.to);
+    }
+
+    private transpileArrayStore (storeIntermediate: Intermediates.ArrayStore): void
+    {
+        const elementPointerRegister =this.loadArrayIndexIntoVariable(
+            storeIntermediate.array,
+            storeIntermediate.index,
+            storeIntermediate.size,
+        );
+
+        const sourceRegister = this.loadReadableValueIntoRegister(storeIntermediate.source);
+
+        this.instructions.push(
+            new Instructions.Instruction(
+                'store',
+                this.getLlvmSizeString(storeIntermediate.size),
+                sourceRegister + ',',
+                this.pointerSizeString,
+                elementPointerRegister,
+            )
+        );
+    }
+
+    private loadArrayIndexIntoVariable (
+        array: IntermediateSymbols.ReadableValue,
+        index: IntermediateSymbols.ReadableValue,
+        size: IntermediateSize
+    ): string
+    {
+        // Arrays are stored as structs: { i64 length, [0 x ElementType] data }
+
+        const arrayPointerRegister = this.loadReadableValueIntoRegister(array);
+        const indexString = this.loadReadableValueIntoRegister(index);
+
+        // Store to the data field (field 1 of the struct) with given index:
+        // getelementptr {i64, [0 x T]}, ptr %array, i32 0, i32 1, i64 %index
+        const elementPointerRegister = this.nextVariableName;
+        const elementTypeString = this.getLlvmSizeString(size);
+        const arrayStructType = `{${this.getLlvmSizeString(IntermediateSize.Native)}, [0 x ${elementTypeString}]}`;
+        const fromString = `getelementptr ${arrayStructType}, ${this.pointerSizeString} ${arrayPointerRegister},`
+            + ` ${this.getLlvmSizeString(IntermediateSize.Int32)} 0, ${this.getLlvmSizeString(IntermediateSize.Int32)} 1,`
+            + ` ${this.getLlvmSizeString(IntermediateSize.Native)} ${indexString}`;
+
+        this.instructions.push(
+            new LlvmInstructions.Assignment(elementPointerRegister, fromString),
+        );
+
+        return elementPointerRegister;
     }
 
     private transpileAdd (addIntermediate: Intermediates.Add): void


### PR DESCRIPTION
This:
```phosphor
module ArrayExample;

import Standard.Conversion;
import Standard.Io;

function main ()
{
    let myArray := new Array[Integer](3);
    myArray.set(0, 1);
    myArray.set(1, 2);
    myArray.set(2, 3);

    let lengthString := Conversion.intToString(myArray.length);
    Io.writeLine('Array length:');
    Io.writeLine(lengthString);

    Io.writeLine('Array elements:');

    let variable index := 0;
    while index < 3
    {
        let gotElement := myArray.get(index);
        let gotString := Conversion.intToString(gotElement);
        Io.writeLine(gotString);
        index := index + 1;
    }
}
```
compiles and running it prints:
```
Array length:
3
Array elements:
1
2
3
```